### PR TITLE
fix connection cache handling

### DIFF
--- a/lib/libgfarm/gfarm/Makefile
+++ b/lib/libgfarm/gfarm/Makefile
@@ -218,7 +218,7 @@ auth_server_uid.lo: $(GFUTIL_SRCDIR)/gfutil.h auth.h gfm_client.h
 auth_server_uid_gsi.lo: $(GFUTIL_SRCDIR)/gfutil.h auth.h gfm_client.h
 config.lo: $(GFUTIL_SRCDIR)/gfutil.h $(GFUTIL_SRCDIR)/hash.h $(GFUTIL_SRCDIR)/lru_cache.h context.h liberror.h patmatch.h hostspec.h param.h sockopt.h host.h auth.h gfpath.h config.h gfm_proto.h gfs_proto.h gfs_profile.h gfm_client.h lookup.h metadb_server.h filesystem.h conn_hash.h conn_cache.h humanize_number.h $(top_builddir)/makes/config.mk # $(GFARM_CONFIG) -> $(sysconfdir)
 config_openssl.lo: config_openssl.h
-config_client.lo: $(GFUTIL_SRCDIR)/timer.h $(GFUTIL_SRCDIR)/gfutil.h context.h liberror.h gfs_profile.h host.h auth.h gfpath.h config.h config_openssl.h gfm_client.h gfs_proto.h gfs_client.h lookup.h filesystem.h metadb_server.h
+config_client.lo: $(GFUTIL_SRCDIR)/timer.h $(GFUTIL_SRCDIR)/gfutil.h context.h liberror.h gfs_profile.h host.h auth.h gfpath.h config.h config_openssl.h gfm_client.h gfs_proto.h gfs_client.h lookup.h filesystem.h metadb_server.h schedule.h gfs_rdma.h
 config_server.lo: $(GFUTIL_SRCDIR)/gfutil.h context.h liberror.h auth.h gfpath.h config.h config_openssl.h
 conn_cache.lo: $(GFUTIL_SRCDIR)/gfutil.h $(GFUTIL_SRCDIR)/hash.h $(GFUTIL_SRCDIR)/lru_cache.h $(GFUTIL_SRCDIR)/thrsubr.h conn_hash.h conn_cache.h
 conn_hash.lo: $(GFUTIL_SRCDIR)/hash.h conn_hash.h

--- a/lib/libgfarm/gfarm/config_client.c
+++ b/lib/libgfarm/gfarm/config_client.c
@@ -28,6 +28,7 @@
 #include "lookup.h"
 #include "filesystem.h"
 #include "metadb_server.h"
+#include "schedule.h"
 
 #include "gfs_rdma.h"
 
@@ -172,6 +173,7 @@ gfarm_initialize(int *argcp, char ***argvp)
 #ifdef HAVE_INFINIBAND
 	gfs_ib_rdma_initialize(0);
 #endif
+	gfarm_schedule_init();
 
 	return (GFARM_ERR_NO_ERROR);
 }

--- a/lib/libgfarm/gfarm/conn_cache.c
+++ b/lib/libgfarm/gfarm/conn_cache.c
@@ -507,8 +507,8 @@ gfp_cached_connection_acquire(struct gfp_conn_cache *cache,
 
 		while (connection->initialization_state ==
 		       GFP_CONN_INITIALIZING) {
-			gfarm_cond_wait(&cache->mutex,
-			    &connection->conn_lock,
+			gfarm_cond_wait(&connection->initialized,
+			    &cache->mutex,
 			    diag, "initialized");
 		}
 		state = connection->initialization_state;

--- a/lib/libgfarm/gfarm/conn_cache.c
+++ b/lib/libgfarm/gfarm/conn_cache.c
@@ -507,7 +507,7 @@ gfp_cached_connection_acquire(struct gfp_conn_cache *cache,
 
 		while (connection->initialization_state ==
 		       GFP_CONN_INITIALIZING) {
-			gfarm_cond_wait(&connection->initialized,
+			gfarm_cond_wait(&cache->mutex,
 			    &connection->conn_lock,
 			    diag, "initialized");
 		}

--- a/lib/libgfarm/gfarm/conn_cache.h
+++ b/lib/libgfarm/gfarm/conn_cache.h
@@ -42,6 +42,10 @@ void *gfp_cached_connection_get_data(struct gfp_cached_connection *);
 void gfp_cached_connection_set_data(struct gfp_cached_connection *, void *);
 void gfp_cached_connection_set_dispose_data(struct gfp_cached_connection *,
 	void (*)(void *));
+void gfp_cached_connection_initialization_succeeded(
+	struct gfp_conn_cache *, struct gfp_cached_connection *);
+void gfp_cached_connection_initialization_aborted(
+	struct gfp_conn_cache *, struct gfp_cached_connection *);
 const char *gfp_cached_connection_hostname(struct gfp_cached_connection *);
 const char *gfp_cached_connection_username(struct gfp_cached_connection *);
 int gfp_cached_connection_port(struct gfp_cached_connection *);
@@ -54,6 +58,10 @@ void gfp_connection_unlock(struct gfp_cached_connection *);
 gfarm_error_t gfp_uncached_connection_new(const char *, int, const char *,
 	struct gfp_cached_connection **);
 void gfp_uncached_connection_dispose(struct gfp_cached_connection *);
+void gfp_uncached_connection_initialization_succeeded(
+	struct gfp_cached_connection *);
+void gfp_uncached_connection_initialization_aborted(
+	struct gfp_cached_connection *);
 void gfp_cached_connection_purge_from_cache(struct gfp_conn_cache *,
 	struct gfp_cached_connection *);
 gfarm_error_t gfp_uncached_connection_enter_cache(struct gfp_conn_cache *,

--- a/lib/libgfarm/gfarm/schedule.c
+++ b/lib/libgfarm/gfarm/schedule.c
@@ -613,10 +613,6 @@ search_idle_host_state_init(struct gfm_connection *gfm_server)
 		gflog_notice(GFARM_MSG_1004312, "%s: network_list_init: %s",
 		    diag, gfarm_error_string(e));
 
-	/* when a connection error happens, make the host unavailable. */
-	gfs_client_add_hook_for_connection_error(
-		gfarm_schedule_host_cache_purge);
-
 	return (GFARM_ERR_NO_ERROR);
 }
 
@@ -2390,6 +2386,13 @@ gfarm_schedule_cache_dump(void)
 	gfarm_schedule_host_cache_dump();
 }
 
+void
+gfarm_schedule_init(void)
+{
+	/* when a connection error happens, make the host unavailable. */
+	gfs_client_add_hook_for_connection_error(
+		gfarm_schedule_host_cache_purge);
+}
 
 #if 0 /* not yet in gfarm v2 */
 

--- a/lib/libgfarm/gfarm/schedule.h
+++ b/lib/libgfarm/gfarm/schedule.h
@@ -31,6 +31,8 @@ void gfarm_schedule_host_unused(const char *, int, const char *,
 
 int gfm_host_is_in_local_net(struct gfm_connection *, const char *);
 
+void gfarm_schedule_init(void);
+
 #if 0 /* not yet in gfarm v2 */
 
 int gfarm_is_active_fsnode(void);


### PR DESCRIPTION
this fixes the following problems

* creation of gfm_client_connection in userland has race condition
* creation of gfm_client_connection and gfs_client_connection in kernel is using sleep+polling loop 
* missing pthread_mutex_destroy() in gfp_cached_connection
* gfm_name2_op0(): missing gfm_client_connection_unlock() in case of the continue statement
* gfm_name2_op0(): locking same gfm_connection twice in case of same_mds
* redundant connection lock
* missing connection lock in gfs_client_sendfile(), gfs_client_recvfile() and gfs_client_replica_recv_*()
* GFS_CLIENT_MUTEX is overblocking