### PR TITLE
implement #1121: export functions which are needed by gfarm-gridftp-dsi

### DIFF
--- a/include/gfarm/gfarm_misc.h
+++ b/include/gfarm/gfarm_misc.h
@@ -61,12 +61,22 @@ gfarm_error_t gfarm_set_global_user_for_this_local_account(void);
 gfarm_error_t gfarm_initialize(int *, char ***);
 gfarm_error_t gfarm_terminate(void);
 gfarm_error_t gfarm_config_read(void);
-gfarm_error_t gfarm_auth_method_gsi_available(void);
 
 const char *gfarm_version(void);
 int gfarm_version_major(void);
 int gfarm_version_minor(void);
 int gfarm_version_teeny(void);
+
+int gfarm_get_client_file_bufsize(void);
+
+/*
+ * authentication
+ */
+gfarm_error_t gfarm_auth_method_gsi_available(void);
+char *gfarm_gsi_client_cred_name(void);
+#ifdef GFARM_USE_GSSAPI
+void gfarm_gsi_client_cred_set(gss_cred_id_t);
+#endif
 
 /*
  * GFarm URL and pathname handling

--- a/lib/libgfarm/gfarm/auth_client_gsi.c
+++ b/lib/libgfarm/gfarm/auth_client_gsi.c
@@ -158,7 +158,7 @@ gfarm_auth_request_gsi(struct gfp_xdr *conn,
 		    service_tag, hostname, gfarm_error_string(e));
 		return (e);
 	}
-	cred = gfarm_gsi_get_delegated_cred();
+	cred = gfarm_gsi_client_cred_get();
 	if (cred == GSS_C_NO_CREDENTIAL) { /* if not delegated */
 		e = gfarm_gsi_acquire_client_credential(hostname, self_type,
 		    &cred, &initiator_name);
@@ -434,7 +434,7 @@ gfarm_auth_request_gsi_multiplexed(struct gfarm_eventqueue *q,
 	}
 
 	state->cred_acquired = 0;
-	state->cred = gfarm_gsi_get_delegated_cred();
+	state->cred = gfarm_gsi_client_cred_get();
 	if (state->cred == GSS_C_NO_CREDENTIAL) { /* if not delegated */
 		e = gfarm_gsi_acquire_client_credential(hostname, self_type,
 		    &state->cred, &initiator_name);

--- a/lib/libgfarm/gfarm/auth_gsi.h
+++ b/lib/libgfarm/gfarm/auth_gsi.h
@@ -1,5 +1,5 @@
 gfarm_error_t gfarm_gsi_cred_config_convert_to_name(
 	enum gfarm_auth_cred_type, char *, char *, char *, gss_name_t *);
 
-void gfarm_gsi_set_delegated_cred(gss_cred_id_t);
-gss_cred_id_t gfarm_gsi_get_delegated_cred(void);
+void gfarm_gsi_client_cred_set(gss_cred_id_t);
+gss_cred_id_t gfarm_gsi_client_cred_get(void);

--- a/lib/libgfarm/gfarm/auth_server_gsi.c
+++ b/lib/libgfarm/gfarm/auth_server_gsi.c
@@ -277,7 +277,7 @@ gfarm_authorize_gsi_common0(struct gfp_xdr *conn, int switch_to,
 		 * in gfmd, but it is not harmful since gfmd currently
 		 * does not support to use delegated credential.
 		 */
-		gfarm_gsi_set_delegated_cred(
+		gfarm_gsi_client_cred_set(
 		    gfarmSecSessionGetDelegatedCredential(session));
 	}
 

--- a/lib/libgfarm/gfarm/config.c
+++ b/lib/libgfarm/gfarm/config.c
@@ -1447,9 +1447,15 @@ gfarm_set_metadb_server_force_slave(int slave)
 }
 
 char *
-gfarm_get_shared_key_file()
+gfarm_get_shared_key_file(void)
 {
 	return (staticp->shared_key_file);
+}
+
+int
+gfarm_get_client_file_bufsize(void)
+{
+	return (gfarm_ctxp->client_file_bufsize);
 }
 
 enum gfarm_spool_check_level


### PR DESCRIPTION
the newly exported functions are:
gfarm_get_client_file_bufsize()
gfarm_gsi_client_cred_name()
gfarm_gsi_client_cred_set()

Currently, gfarm-gridftp-dsi is calling private functions,
but that's quite dangerous.

NOTE:
gfarm-gridftp-dsi should do the followings:
* #define GFARM_USE_GSSAPI before #include <gfarm/gfarm_misc.h>
* its gfarm_config_local_name_to_string() call should be replaced by
  gfarm_get_client_file_bufsize()
* its gfarm_gsi_set_delegated_cred() call should be replaced by
  gfarm_gsi_client_cred_set()

the gfarm_gsi_set_delegated_cred() function is deprecated.
it will be removed in future.