### PR TITLE
make gfarm-2.8.0 clients work with gfarm-2.7.13 or newer servers

### DIFF
--- a/doc/docbook/en/ref/man5/gfarm2.conf.5.docbook
+++ b/doc/docbook/en/ref/man5/gfarm2.conf.5.docbook
@@ -5,7 +5,7 @@
 
 <refentry id="gfarm2.conf.5">
 
-<refentryinfo><date>2 Sep 2023</date></refentryinfo>
+<refentryinfo><date>11 Sep 2023</date></refentryinfo>
 
 <refmeta>
 <refentrytitle>gfarm2.conf</refentrytitle>
@@ -123,6 +123,33 @@ The default limit is 20 level.
 <para>For example,</para>
 <literallayout format="linespecific" class="normal">
 	include_nesting_limit 30
+</literallayout>
+</listitem>
+</varlistentry>
+
+<varlistentry>
+<term><token>protocol_compat</token> <parameter moreinfo="none">version_string</parameter></term>
+<listitem>
+<para>
+Gfarm client will not work if its version is newer than the server version.
+However, it may be possible to make it work by using this setting.
+</para>
+<para>
+Specifing the version string to the GFARM_PROTOCOL_COMPAT environment variable
+has the same effect.
+</para>
+<para>
+The current possible setting as a version string is 2.7.13,
+which specifies that gfarm will run on a combination of
+a gfarm-2.7.13 or newer server and a gfarm-2.8.0 or later client.
+</para>
+<para>
+This directive is only available for clients in gfarm2.conf.
+Both gfsd and gfmd ignore this setting in gfarm2.conf and gfmd.conf.
+</para>
+<para>例:</para>
+<literallayout format="linespecific" class="normal">
+	protocol_compat 2.7.13
 </literallayout>
 </listitem>
 </varlistentry>
@@ -3465,6 +3492,7 @@ The default for this parameter is determined at OpenSSL compile time.
 <listitem><literallayout format="linespecific" class="normal">
 	&lt;include_statement&gt; |
 	&lt;include_nesting_limit_statement&gt; |
+	&lt;protocol_compat_statement&gt; |
 	&lt;spool_statement&gt; |
 	&lt;spool_server_listen_address_statement&gt; |
 	&lt;spool_server_listen_backlog_statement&gt; |
@@ -3633,6 +3661,11 @@ The default for this parameter is determined at OpenSSL compile time.
 <varlistentry>
 <term>&lt;include_nesting_limit_statement&gt; ::=</term>
 <listitem><literallayout format="linespecific" class="normal">"include_nesting_limit" &lt;number&gt;</literallayout></listitem>
+</varlistentry>
+
+<varlistentry>
+<term>&lt;protocol_compat_statement&gt; ::=</term>
+<listitem><literallayout format="linespecific" class="normal">"protocol_compat" &lt;version_string&gt;</literallayout></listitem>
 </varlistentry>
 
 <varlistentry>

--- a/doc/docbook/en/ref/man5/gfarm2.conf.5.docbook
+++ b/doc/docbook/en/ref/man5/gfarm2.conf.5.docbook
@@ -147,7 +147,7 @@ a gfarm-2.7.13 or newer server and a gfarm-2.8.0 or later client.
 This directive is only available for clients in gfarm2.conf.
 Both gfsd and gfmd ignore this setting in gfarm2.conf and gfmd.conf.
 </para>
-<para>例:</para>
+<para>For example,</para>
 <literallayout format="linespecific" class="normal">
 	protocol_compat 2.7.13
 </literallayout>

--- a/doc/docbook/ja/ref/man5/gfarm2.conf.5.docbook
+++ b/doc/docbook/ja/ref/man5/gfarm2.conf.5.docbook
@@ -5,7 +5,7 @@
 
 <refentry id="gfarm2.conf.5">
 
-<refentryinfo><date>2 Sep 2023</date></refentryinfo>
+<refentryinfo><date>11 Sep 2023</date></refentryinfo>
 
 <refmeta>
 <refentrytitle>gfarm2.conf</refentrytitle>
@@ -136,6 +136,34 @@ IPアドレスと、"/"で区切られた0〜31までの数字で、ネットワ
 <para>例:</para>
 <literallayout format="linespecific" class="normal">
 	include_nesting_limit 30
+</literallayout>
+</listitem>
+</varlistentry>
+
+<varlistentry>
+<term><token>protocol_compat</token> <parameter moreinfo="none">バージョン文字列</parameter></term>
+<listitem>
+<para>
+Gfarmクライアントは、そのバージョンがサーバーのバージョンよりも新しいと
+動作しません。
+しかしこの設定を行うことにより動作させることができる場合があります。
+</para>
+<para>
+環境変数 GFARM_PROTOCOL_COMPAT にこのバージョン文字列を指定した場合も
+同じ効果があります。
+</para>
+<para>
+現在バージョン文字列として可能な設定は 2.7.13 であり、
+これは gfarm-2.7.13 ないしそれよりも新しいサーバーと
+gfarm-2.8.0 以降のクライアントの組合せで動作させるための指定です。
+</para>
+<para>
+この文は、クライアントが参照するgfarm2.confのみで有効です。
+gfsd や gfmd は、gfarm2.conf や gfmd.conf 中のこの文を無視します。
+</para>
+<para>例:</para>
+<literallayout format="linespecific" class="normal">
+	protocol_compat 2.7.13
 </literallayout>
 </listitem>
 </varlistentry>
@@ -3410,6 +3438,7 @@ OpenSSL の security_level 機能の数値を指定します。
 <listitem><literallayout format="linespecific" class="normal">
 	&lt;include_statement&gt; |
 	&lt;include_nesting_limit_statement&gt; |
+	&lt;protocol_compat_statement&gt; |
 	&lt;spool_statement&gt; |
 	&lt;spool_server_listen_address_statement&gt; |
 	&lt;spool_server_listen_backlog_statement&gt; |
@@ -3578,6 +3607,11 @@ OpenSSL の security_level 機能の数値を指定します。
 <varlistentry>
 <term>&lt;include_nesting_limit_statement&gt; ::=</term>
 <listitem><literallayout format="linespecific" class="normal">"include_nesting_limit" &lt;number&gt;</literallayout></listitem>
+</varlistentry>
+
+<varlistentry>
+<term>&lt;protocol_compat_statement&gt; ::=</term>
+<listitem><literallayout format="linespecific" class="normal">"protocol_compat" &lt;version_string&gt;</literallayout></listitem>
 </varlistentry>
 
 <varlistentry>

--- a/doc/html/en/ref/man5/gfarm2.conf.5.html
+++ b/doc/html/en/ref/man5/gfarm2.conf.5.html
@@ -82,6 +82,30 @@ The default limit is 20 level.
 	include_nesting_limit 30<br>
 </p></div>
 </dd>
+<dt><span class="term"><span class="token">protocol_compat</span> <em class="parameter"><code>version_string</code></em></span></dt>
+<dd>
+<p>
+Gfarm client will not work if its version is newer than the server version.
+However, it may be possible to make it work by using this setting.
+</p>
+<p>
+Specifing the version string to the GFARM_PROTOCOL_COMPAT environment variable
+has the same effect.
+</p>
+<p>
+The current possible setting as a version string is 2.7.13,
+which specifies that gfarm will run on a combination of
+a gfarm-2.7.13 or newer server and a gfarm-2.8.0 or later client.
+</p>
+<p>
+This directive is only available for clients in gfarm2.conf.
+Both gfsd and gfmd ignore this setting in gfarm2.conf and gfmd.conf.
+</p>
+<p>例:</p>
+<div class="literallayout"><p><br>
+	protocol_compat 2.7.13<br>
+</p></div>
+</dd>
 <dt><span class="term"><span class="token">spool</span> <em class="parameter"><code>directory</code></em></span></dt>
 <dd>
 <p>The <span class="token">spool</span> statement specifies a spool directory
@@ -2705,6 +2729,7 @@ The default for this parameter is determined at OpenSSL compile time.
 <dd><div class="literallayout"><p><br>
 	&lt;include_statement&gt; |<br>
 	&lt;include_nesting_limit_statement&gt; |<br>
+	&lt;protocol_compat_statement&gt; |<br>
 	&lt;spool_statement&gt; |<br>
 	&lt;spool_server_listen_address_statement&gt; |<br>
 	&lt;spool_server_listen_backlog_statement&gt; |<br>
@@ -2867,6 +2892,8 @@ The default for this parameter is determined at OpenSSL compile time.
 <dd><div class="literallayout"><p>"include" &lt;pathname&gt;</p></div></dd>
 <dt><span class="term">&lt;include_nesting_limit_statement&gt; ::=</span></dt>
 <dd><div class="literallayout"><p>"include_nesting_limit" &lt;number&gt;</p></div></dd>
+<dt><span class="term">&lt;protocol_compat_statement&gt; ::=</span></dt>
+<dd><div class="literallayout"><p>"protocol_compat" &lt;version_string&gt;</p></div></dd>
 <dt><span class="term">&lt;spool_statement&gt; ::=</span></dt>
 <dd><div class="literallayout"><p>"spool" &lt;pathname&gt;</p></div></dd>
 <dt><span class="term">&lt;spool_server_listen_address_statement&gt; ::=</span></dt>

--- a/doc/html/en/ref/man5/gfarm2.conf.5.html
+++ b/doc/html/en/ref/man5/gfarm2.conf.5.html
@@ -101,7 +101,7 @@ a gfarm-2.7.13 or newer server and a gfarm-2.8.0 or later client.
 This directive is only available for clients in gfarm2.conf.
 Both gfsd and gfmd ignore this setting in gfarm2.conf and gfmd.conf.
 </p>
-<p>例:</p>
+<p>For example,</p>
 <div class="literallayout"><p><br>
 	protocol_compat 2.7.13<br>
 </p></div>

--- a/doc/html/ja/ref/man5/gfarm2.conf.5.html
+++ b/doc/html/ja/ref/man5/gfarm2.conf.5.html
@@ -90,6 +90,31 @@ IPアドレスと、"/"で区切られた0〜31までの数字で、ネットワ
 	include_nesting_limit 30<br>
 </p></div>
 </dd>
+<dt><span class="term"><span class="token">protocol_compat</span> <em class="parameter"><code>バージョン文字列</code></em></span></dt>
+<dd>
+<p>
+Gfarmクライアントは、そのバージョンがサーバーのバージョンよりも新しいと
+動作しません。
+しかしこの設定を行うことにより動作させることができる場合があります。
+</p>
+<p>
+環境変数 GFARM_PROTOCOL_COMPAT にこのバージョン文字列を指定した場合も
+同じ効果があります。
+</p>
+<p>
+現在バージョン文字列として可能な設定は 2.7.13 であり、
+これは gfarm-2.7.13 ないしそれよりも新しいサーバーと
+gfarm-2.8.0 以降のクライアントの組合せで動作させるための指定です。
+</p>
+<p>
+この文は、クライアントが参照するgfarm2.confのみで有効です。
+gfsd や gfmd は、gfarm2.conf や gfmd.conf 中のこの文を無視します。
+</p>
+<p>例:</p>
+<div class="literallayout"><p><br>
+	protocol_compat 2.7.13<br>
+</p></div>
+</dd>
 <dt><span class="term"><span class="token">spool</span> <em class="parameter"><code>gfsdスプール・ディレクトリ</code></em></span></dt>
 <dd>
 <p>gfsdが、gfarmファイルの実体を保持するディレクトリ名を
@@ -2657,6 +2682,7 @@ OpenSSL の security_level 機能の数値を指定します。
 <dd><div class="literallayout"><p><br>
 	&lt;include_statement&gt; |<br>
 	&lt;include_nesting_limit_statement&gt; |<br>
+	&lt;protocol_compat_statement&gt; |<br>
 	&lt;spool_statement&gt; |<br>
 	&lt;spool_server_listen_address_statement&gt; |<br>
 	&lt;spool_server_listen_backlog_statement&gt; |<br>
@@ -2819,6 +2845,8 @@ OpenSSL の security_level 機能の数値を指定します。
 <dd><div class="literallayout"><p>"include" &lt;pathname&gt;</p></div></dd>
 <dt><span class="term">&lt;include_nesting_limit_statement&gt; ::=</span></dt>
 <dd><div class="literallayout"><p>"include_nesting_limit" &lt;number&gt;</p></div></dd>
+<dt><span class="term">&lt;protocol_compat_statement&gt; ::=</span></dt>
+<dd><div class="literallayout"><p>"protocol_compat" &lt;version_string&gt;</p></div></dd>
 <dt><span class="term">&lt;spool_statement&gt; ::=</span></dt>
 <dd><div class="literallayout"><p>"spool" &lt;pathname&gt;</p></div></dd>
 <dt><span class="term">&lt;spool_server_listen_address_statement&gt; ::=</span></dt>

--- a/lib/libgfarm/gfarm/auth.h
+++ b/lib/libgfarm/gfarm/auth.h
@@ -104,6 +104,9 @@ enum gfarm_auth_gss_request {
 #define GFARM_IS_AUTH_KERBEROS(auth) \
 	((auth) == GFARM_AUTH_METHOD_KERBEROS || \
 	 (auth) == GFARM_AUTH_METHOD_KERBEROS_AUTH)
+#define GFARM_IS_AUTH_V2_8_OR_LATER(auth) \
+	((auth) >= GFARM_AUTH_METHOD_TLS_SHAREDSECRET)
+
 
 /*
  * GFARM_AUTH_METHOD_TLS_CLIENT_CERTIFICATE dependent constants.

--- a/lib/libgfarm/gfarm/config.h
+++ b/lib/libgfarm/gfarm/config.h
@@ -265,6 +265,8 @@ gfarm_error_t gfm_client_config_get_vars_result(struct gfm_connection *,
 /* miscellaneous */
 extern int gfarm_file_trace;
 
+gfarm_error_t gfarm_set_protocol_compat(const char *);
+
 void gfarm_config_set_filename(char *);
 char *gfarm_config_get_filename(void);
 

--- a/lib/libgfarm/gfarm/config_client.c
+++ b/lib/libgfarm/gfarm/config_client.c
@@ -160,6 +160,7 @@ gfarm_config_read(void)
 static void
 gfarm_parse_env_client(void)
 {
+	gfarm_error_t e;
 	char *env;
 
 	if ((env = getenv("GFARM_FLAGS")) != NULL) {
@@ -171,8 +172,15 @@ gfarm_parse_env_client(void)
 			}
 		}
 	}
-}
 
+	if ((env = getenv("GFARM_PROTOCOL_COMPAT")) != NULL) {
+		e = gfarm_set_protocol_compat(env);
+		if (e != GFARM_ERR_NO_ERROR) {
+			fprintf(stderr, "$GFARM_PROTOCOL_COMPAT=\"%s\": %s\n",
+			    env, gfarm_error_string(e));
+		}
+	}
+}
 
 /*
  * the following function is for client,

--- a/lib/libgfarm/gfarm/config_client.c
+++ b/lib/libgfarm/gfarm/config_client.c
@@ -176,7 +176,8 @@ gfarm_parse_env_client(void)
 	if ((env = getenv("GFARM_PROTOCOL_COMPAT")) != NULL) {
 		e = gfarm_set_protocol_compat(env);
 		if (e != GFARM_ERR_NO_ERROR) {
-			fprintf(stderr, "$GFARM_PROTOCOL_COMPAT=\"%s\": %s\n",
+			gflog_warning(GFARM_MSG_UNFIXED,
+			    "$GFARM_PROTOCOL_COMPAT=\"%s\": %s",
 			    env, gfarm_error_string(e));
 		}
 	}

--- a/lib/libgfarm/gfarm/gfm_client.c
+++ b/lib/libgfarm/gfarm/gfm_client.c
@@ -1817,7 +1817,8 @@ gfm_client_user_info_get_mine_request(struct gfm_connection *gfm_server)
 {
 	gfarm_error_t e = GFARM_ERR_NO_ERROR;
 
-	if (staticp->gfm_proto_version_default >= GFM_PROTOCOL_VERSION_V2_8_0) {
+	if (staticp->gfm_proto_version_default >= GFM_PROTOCOL_VERSION_V2_8_0
+	    || GFARM_IS_AUTH_V2_8_OR_LATER(gfm_server->auth_method)) {
 		e = gfm_client_user_info_get_my_own_request(gfm_server);
 	} else {
 #ifdef HAVE_GSI
@@ -1845,7 +1846,8 @@ gfm_client_user_info_get_mine_result(struct gfm_connection *gfm_server,
 {
 	gfarm_error_t e = GFARM_ERR_NO_ERROR;
 
-	if (staticp->gfm_proto_version_default >= GFM_PROTOCOL_VERSION_V2_8_0) {
+	if (staticp->gfm_proto_version_default >= GFM_PROTOCOL_VERSION_V2_8_0
+	    || GFARM_IS_AUTH_V2_8_OR_LATER(gfm_server->auth_method)) {
 		e = gfm_client_user_info_get_my_own_result(gfm_server, user);
 	} else {
 #ifdef HAVE_GSI

--- a/lib/libgfarm/gfarm/gfm_client.c
+++ b/lib/libgfarm/gfarm/gfm_client.c
@@ -1828,10 +1828,13 @@ gfm_client_user_info_get_mine_request(struct gfm_connection *gfm_server)
 		    != NULL) {
 			e = gfm_client_user_info_get_by_gsi_dn_request(
 			    gfm_server, gsi_dn);
-		}
-#else
-		/* do nothing */
+		} else
 #endif
+		{
+			e = gfm_client_rpc_request(gfm_server,
+			    GFM_PROTO_USER_INFO_GET_BY_NAMES, "is",
+			    (gfarm_int32_t)1, gfm_client_username(gfm_server));
+		}
 	}
 	return (e);
 }
@@ -1853,10 +1856,17 @@ gfm_client_user_info_get_mine_result(struct gfm_connection *gfm_server,
 		    != NULL) {
 			e = gfm_client_user_info_get_by_gsi_dn_result(
 			    gfm_server, user);
-		}
-#else
-		/* do nothing */
+		} else
 #endif
+		{
+			/* GFM_PROTO_USER_INFO_GET_BY_NAMES:nusers==1 result */
+			e = gfm_client_rpc_result(gfm_server, 0, "");
+			if (e == GFARM_ERR_NO_ERROR)
+				e = gfm_client_rpc_result(
+				    gfm_server, 0, "ssss",
+				    &user->username, &user->realname,
+				    &user->homedir, &user->gsi_dn);
+		}
 	}
 	return (e);
 }

--- a/lib/libgfarm/gfarm/gfm_client.h
+++ b/lib/libgfarm/gfarm/gfm_client.h
@@ -36,6 +36,8 @@ void gfarm_host_sched_info_free(int, struct gfarm_host_sched_info *);
 extern char *gfarm_auth_user_id_type_list[];
 extern int gfarm_auth_user_id_type_number;
 
+gfarm_error_t gfm_client_set_protocol_compat(int);
+
 int gfm_client_connection_empty(struct gfm_connection *);
 int gfm_client_is_connection_error(gfarm_error_t);
 struct gfp_xdr *gfm_client_connection_conn(struct gfm_connection *);
@@ -114,6 +116,9 @@ gfarm_error_t gfm_client_user_info_get_by_gsi_dn(struct gfm_connection *,
 	const char *, struct gfarm_user_info *);
 gfarm_error_t gfm_client_user_info_get_my_own_request(struct gfm_connection *);
 gfarm_error_t gfm_client_user_info_get_my_own_result(struct gfm_connection *,
+	struct gfarm_user_info *);
+gfarm_error_t gfm_client_user_info_get_mine_request(struct gfm_connection *);
+gfarm_error_t gfm_client_user_info_get_mine_result(struct gfm_connection *,
 	struct gfarm_user_info *);
 gfarm_error_t gfm_client_user_info_set(struct gfm_connection *,
 	const struct gfarm_user_info *);

--- a/man/ja/man5/gfarm2.conf.5
+++ b/man/ja/man5/gfarm2.conf.5
@@ -2,12 +2,12 @@
 .\"     Title: gfarm2.conf
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 2 Sep 2023
+.\"      Date: 11 Sep 2023
 .\"    Manual: Gfarm
 .\"    Source: Gfarm
 .\"  Language: English
 .\"
-.TH "GFARM2\&.CONF" "5" "2 Sep 2023" "Gfarm" "Gfarm"
+.TH "GFARM2\&.CONF" "5" "11 Sep 2023" "Gfarm" "Gfarm"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -102,6 +102,29 @@ include
 .\}
 .nf
 	include_nesting_limit 30
+.fi
+.if n \{\
+.RE
+.\}
+.RE
+.PP
+protocol_compat \fIバージョン文字列\fR
+.RS 4
+Gfarmクライアントは、そのバージョンがサーバーのバージョンよりも新しいと 動作しません。 しかしこの設定を行うことにより動作させることができる場合があります。
+.sp
+環境変数 GFARM_PROTOCOL_COMPAT にこのバージョン文字列を指定した場合も 同じ効果があります。
+.sp
+現在バージョン文字列として可能な設定は 2\&.7\&.13 であり、 これは gfarm\-2\&.7\&.13 ないしそれよりも新しいサーバーと gfarm\-2\&.8\&.0 以降のクライアントの組合せで動作させるための指定です。
+.sp
+この文は、クライアントが参照するgfarm2\&.confのみで有効です。 gfsd や gfmd は、gfarm2\&.conf や gfmd\&.conf 中のこの文を無視します。
+.sp
+例:
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+	protocol_compat 2\&.7\&.13
 .fi
 .if n \{\
 .RE
@@ -3200,6 +3223,7 @@ gfarm2\&.confの文法をBNFで記述すると、下記のようになります�
 .nf
 	<include_statement> |
 	<include_nesting_limit_statement> |
+	<protocol_compat_statement> |
 	<spool_statement> |
 	<spool_server_listen_address_statement> |
 	<spool_server_listen_backlog_statement> |
@@ -3385,6 +3409,20 @@ gfarm2\&.confの文法をBNFで記述すると、下記のようになります�
 .\}
 .nf
 "include_nesting_limit" <number>
+.fi
+.if n \{\
+.RE
+.\}
+.RE
+.PP
+<protocol_compat_statement> ::=
+.RS 4
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+"protocol_compat" <version_string>
 .fi
 .if n \{\
 .RE

--- a/man/man5/gfarm2.conf.5
+++ b/man/man5/gfarm2.conf.5
@@ -115,7 +115,7 @@ The current possible setting as a version string is 2\&.7\&.13, which specifies 
 .sp
 This directive is only available for clients in gfarm2\&.conf\&. Both gfsd and gfmd ignore this setting in gfarm2\&.conf and gfmd\&.conf\&.
 .sp
-例:
+For example,
 .sp
 .if n \{\
 .RS 4

--- a/man/man5/gfarm2.conf.5
+++ b/man/man5/gfarm2.conf.5
@@ -2,12 +2,12 @@
 .\"     Title: gfarm2.conf
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 2 Sep 2023
+.\"      Date: 11 Sep 2023
 .\"    Manual: Gfarm
 .\"    Source: Gfarm
 .\"  Language: English
 .\"
-.TH "GFARM2\&.CONF" "5" "2 Sep 2023" "Gfarm" "Gfarm"
+.TH "GFARM2\&.CONF" "5" "11 Sep 2023" "Gfarm" "Gfarm"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -99,6 +99,29 @@ For example,
 .\}
 .nf
 	include_nesting_limit 30
+.fi
+.if n \{\
+.RE
+.\}
+.RE
+.PP
+protocol_compat \fIversion_string\fR
+.RS 4
+Gfarm client will not work if its version is newer than the server version\&. However, it may be possible to make it work by using this setting\&.
+.sp
+Specifing the version string to the GFARM_PROTOCOL_COMPAT environment variable has the same effect\&.
+.sp
+The current possible setting as a version string is 2\&.7\&.13, which specifies that gfarm will run on a combination of a gfarm\-2\&.7\&.13 or newer server and a gfarm\-2\&.8\&.0 or later client\&.
+.sp
+This directive is only available for clients in gfarm2\&.conf\&. Both gfsd and gfmd ignore this setting in gfarm2\&.conf and gfmd\&.conf\&.
+.sp
+例:
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+	protocol_compat 2\&.7\&.13
 .fi
 .if n \{\
 .RE
@@ -3345,6 +3368,7 @@ This is a grammar of gfarm2\&.conf described by the BNF notation\&.
 .nf
 	<include_statement> |
 	<include_nesting_limit_statement> |
+	<protocol_compat_statement> |
 	<spool_statement> |
 	<spool_server_listen_address_statement> |
 	<spool_server_listen_backlog_statement> |
@@ -3530,6 +3554,20 @@ This is a grammar of gfarm2\&.conf described by the BNF notation\&.
 .\}
 .nf
 "include_nesting_limit" <number>
+.fi
+.if n \{\
+.RE
+.\}
+.RE
+.PP
+<protocol_compat_statement> ::=
+.RS 4
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+"protocol_compat" <version_string>
 .fi
 .if n \{\
 .RE


### PR DESCRIPTION
by "protocol_compat 2.7.13" directive
or
by $GFARM_PROTOCOL_COMPAT=2.7.13 environment variable