### PR TITLE
make gfarm-gridftp-dsi work with gfarm-2.8

### DIFF
--- a/lib/libgfarm/Makefile
+++ b/lib/libgfarm/Makefile
@@ -6,28 +6,13 @@ srcdir = .
 
 include $(top_srcdir)/makes/var.mk
 
-# shared object version
-LTLDFLAGS = $(LTFLAGS_SHARELIB_IN) $(libdir)
-LT_CURRENT=1
-LT_REVISION=0
-LT_AGE=0
-
-LIBRARY = libgfarm.la
-CFLAGS = $(COMMON_CFLAGS)
-LDLIBS = $(globus_gssapi_libs) $(openssl_libs) $(LIBS)
-
 GLOBUS_TARGETS = gfsl_gsi
 KERBEROS_TARGETS = gfsl_kerberos
 SUBDIRS = gfutil $(globus_targets) $(kerberos_targets) gfarm
 
-OBJS =	gfutil/libgfutil.la gfarm/libgfarmcore.la
-
-all: subdir-all $(LIBRARY)
-
-$(OBJS): subdir-all
+all: subdir-all
 
 include $(top_srcdir)/makes/subdir.mk
-include $(top_srcdir)/makes/lib.mk
 
 clean:
 	$(RM) -f hook_test hook_test_mpi

--- a/lib/libgfarm/gfarm/Makefile
+++ b/lib/libgfarm/gfarm/Makefile
@@ -13,8 +13,13 @@ PUBLIC_RULE  = /dev/null
 PUBLIC_SRCS  =
 PUBLIC_OBJS  =
 
-LIBRARY = libgfarmcore.la
-LIBRARY_RESULT = # do not install
+# shared object version
+LTLDFLAGS = $(LTFLAGS_SHARELIB_IN) $(libdir)
+LT_CURRENT=1
+LT_REVISION=0
+LT_AGE=0
+
+LIBRARY = libgfarm.la
 
 GSS_SRCS = gss.c auth_client_gss.c auth_common_gss.c \
 	auth_server_gss.c io_gfsl.c
@@ -228,6 +233,7 @@ CFLAGS = $(pthread_includes) \
 	$(gss_cflags) $(metadb_client_includes) $(openssl_includes) \
 	$(optional_cflags) $(rdma_includes) \
 	-DGFARM_CONFIG='"$(sysconfdir)/gfarm2.conf"'
+LDLIBS = ../gfutil/libgfutil.la $(globus_gssapi_libs) $(openssl_libs) $(LIBS)
 
 all: $(LIBRARY)
 

--- a/lib/libgfarm/gfsl/Makefile
+++ b/lib/libgfarm/gfsl/Makefile
@@ -14,7 +14,7 @@ CFLAGS = $(COMMON_CFLAGS) -I$(GFUTIL_SRCDIR) -I$(GFSL_SRCDIR) \
 	$(GSSAPI_INCLUDES) \
 	-DGFARM_INSTALL_ETC_DIR='"$(sysconfdir)"' \
 	-DGLOBUS_FAKE_GSS_C_NT_USER=0 # see gss.c
-LDLIBS = $(GSSAPI_LIBS) $(openssl_libs) $(LIBS)
+LDLIBS = ../gfutil/libgfutil.la $(GSSAPI_LIBS) $(openssl_libs) $(LIBS)
 
 ### for library
 

--- a/lib/libgfarm/gfutil/Makefile
+++ b/lib/libgfarm/gfutil/Makefile
@@ -6,8 +6,13 @@ srcdir = .
 
 include $(top_srcdir)/makes/var.mk
 
+# shared object version
+LTLDFLAGS = $(LTFLAGS_SHARELIB_IN) $(libdir)
+LT_CURRENT=1
+LT_REVISION=0
+LT_AGE=0
+
 LIBRARY = libgfutil.la
-LIBRARY_RESULT = # do not install
 
 SRCS =	alloc.c \
 	assert.c \

--- a/makes/var.mk
+++ b/makes/var.mk
@@ -26,12 +26,16 @@ COMMON_CFLAGS = $(OPTFLAGS) $(largefile_cflags) \
 	-I$(top_builddir)/include -I$(top_srcdir)/include \
 	-DCOMPAT_GFARM_2_3
 COMMON_LDFLAGS = $(largefile_ldflags) $(dynamic_ldflags)
-GFARMLIB = -L$(top_builddir)/lib/libgfarm -lgfarm \
+GFARMLIB = \
+	-L$(top_builddir)/lib/libgfarm/gfarm -lgfarm \
+	-L$(top_builddir)/lib/libgfarm/gfutil -lgfutil \
 	$(globus_gssapi_libs) $(openssl_libs)
 
 INC_SRCDIR = $(top_srcdir)/include/gfarm
 INC_BUILDDIR = $(top_builddir)/include/gfarm
-DEPGFARMLIB = $(top_builddir)/lib/libgfarm/libgfarm.la
+DEPGFARMLIB = \
+	$(top_builddir)/lib/libgfarm/gfarm/libgfarm.la \
+	$(top_builddir)/lib/libgfarm/gfutil/libgfutil.la
 DEPGFARMINC = $(INC_BUILDDIR)/gfarm_config.h $(INC_SRCDIR)/gfarm.h $(INC_SRCDIR)/gflog.h $(INC_SRCDIR)/error.h $(INC_SRCDIR)/gfarm_misc.h $(INC_SRCDIR)/gfarm_stringlist.h $(INC_SRCDIR)/gfs.h $(INC_SRCDIR)/gfs_glob.h
 
 # ns

--- a/package/redhat/gfarm.spec
+++ b/package/redhat/gfarm.spec
@@ -1372,6 +1372,9 @@ fi
 %{prefix}/include/gfarm/gfs_glob.h
 # XXX - this should not be here
 %{prefix}/include/gfarm/gfarm_msg_enums.h
+%{lib_prefix}/libgfutil.a
+%{lib_prefix}/libgfutil.la
+%{lib_prefix}/libgfutil.so
 %{lib_prefix}/libgfarm.a
 %{lib_prefix}/libgfarm.la
 %{lib_prefix}/libgfarm.so


### PR DESCRIPTION
globus-gridftp-server calls libglobus_gridftp_server_gfarm.so in dlopen(3) RTLD_LOCAL mode, so libgfsl_gsi.so could not resolve symbols provided by gfutil.
solve it by separating libgfutil.so into an independent shared object.

NOTE: this requires the -lgfutil option when building gfarm2fs