### PR TITLE
gfservice: fix auth detection after AUTH_TYPES change

### DIFF
--- a/doc/docbook/en/ref/man5/gfservice.conf.5.docbook
+++ b/doc/docbook/en/ref/man5/gfservice.conf.5.docbook
@@ -182,9 +182,9 @@ in private mode.
 <para>
 Specify authentication type ("sharedsecret", "gsi" or "gsi_auth").
 If the variable is not declared, its value is chosen from
-<varname>AUTH_TYPE</varname> value output by
+<varname>AUTH_TYPES</varname> value output by
 <command moreinfo="none">config-gfarm -T</command> command executed on gfmd1.
-(Note that the value <varname>AUTH_TYPE</varname> above is affected by
+(Note that the value <varname>AUTH_TYPES</varname> above is affected by
 the variable <varname>gfmd1_CONFIG_GFARM_OPTIONS</varname>.)
 </para>
 </listitem>
@@ -305,9 +305,9 @@ in private mode.
 <para>
 Specify authentication type ("sharedsecret", "gsi" or "gsi_auth").
 If the variable is not declared, its value is chosen from
-<varname>AUTH_TYPE</varname> value output by
+<varname>AUTH_TYPES</varname> value output by
 <command moreinfo="none">config-gfarm -T</command> command executed on gfmd1.
-(Note that the value <varname>AUTH_TYPE</varname> above is affected by
+(Note that the value <varname>AUTH_TYPES</varname> above is affected by
 the variable <varname>gfmd1_CONFIG_GFARM_OPTIONS</varname>.)
 </para>
 </listitem>
@@ -458,9 +458,9 @@ the sub-command <command moreinfo="none">config-client</command> without root pr
 <para>
 Specify authentication type ("sharedsecret", "gsi" or "gsi_auth").
 If the variable is not declared, its value is chosen from
-<varname>AUTH_TYPE</varname> value output by
+<varname>AUTH_TYPES</varname> value output by
 <command moreinfo="none">config-gfarm -T</command> command executed on gfmd1.
-(Note that the value <varname>AUTH_TYPE</varname> above is affected by
+(Note that the value <varname>AUTH_TYPES</varname> above is affected by
 the variable <varname>gfmd1_CONFIG_GFARM_OPTIONS</varname>.)
 </para>
 </listitem>

--- a/doc/docbook/ja/ref/man5/gfservice.conf.5.docbook
+++ b/doc/docbook/ja/ref/man5/gfservice.conf.5.docbook
@@ -182,10 +182,10 @@ gfmd サーバー上で <command moreinfo="none">gfservice-agent</command> コ�
 <para>
 認証タイプ ("sharedsecret", "gsi", "gsi_auth" のいずれか) を指定します。
 この変数が定義されていない場合は、gfmd1 上で
-<command moreinfo="none">config-gfarm</command> を実行したときの
-<varname>AUTH_TYPE</varname> の値が採用されます。
+<command moreinfo="none">config-gfarm -T</command> を実行したときの
+<varname>AUTH_TYPES</varname> の値が採用されます。
 (変数 <varname>gfmd1_CONFIG_GFARM_OPTIONS</varname> の値によって、この
-ときの <varname>AUTH_TYPE</varname> の値は変わるので、注意して下さい。)
+ときの <varname>AUTH_TYPES</varname> の値は変わるので、注意して下さい。)
 </para>
 </listitem>
 </varlistentry>
@@ -305,10 +305,10 @@ gfsd サーバー上で <command moreinfo="none">gfservice-agent</command> コ�
 <para>
 認証タイプ ("sharedsecret", "gsi", "gsi_auth" のいずれか) を指定します。
 この変数が定義されていない場合は、gfmd1 上で
-<command moreinfo="none">config-gfarm</command> を実行したときの
-<varname>AUTH_TYPE</varname> の値が採用されます。
+<command moreinfo="none">config-gfarm -T</command> を実行したときの
+<varname>AUTH_TYPES</varname> の値が採用されます。
 (変数 <varname>gfmd1_CONFIG_GFARM_OPTIONS</varname> の値によって、この
-ときの <varname>AUTH_TYPE</varname> の値は変わるので、注意して下さい。)
+ときの <varname>AUTH_TYPES</varname> の値は変わるので、注意して下さい。)
 </para>
 </listitem>
 </varlistentry>
@@ -460,10 +460,10 @@ gfarm2.confファイルのパスと同じパスを使用します(gfarm2.confフ
 <para>
 認証タイプ ("sharedsecret", "gsi", "gsi_auth" のいずれか) を指定します。
 この変数が定義されていない場合は、gfmd1 上で
-<command moreinfo="none">config-gfarm</command> を実行したときの
-<varname>AUTH_TYPE</varname> の値が採用されます。
+<command moreinfo="none">config-gfarm -T</command> を実行したときの
+<varname>AUTH_TYPES</varname> の値が採用されます。
 (変数 <varname>gfmd1_CONFIG_GFARM_OPTIONS</varname> の値によって、この
-ときの <varname>AUTH_TYPE</varname> の値は変わるので、注意して下さい。)
+ときの <varname>AUTH_TYPES</varname> の値は変わるので、注意して下さい。)
 </para>
 </listitem>
 </varlistentry>

--- a/util/gfservice/gfservice-agent.in
+++ b/util/gfservice/gfservice-agent.in
@@ -131,9 +131,9 @@ set_gfmd_params()
 		&& log_error "failed to get gfmd port"
 	log_debug "set_gfmd_params: set GFMD_PORT=$GFMD_PORT"
 
-	[ "X$AUTH_TYPE" = X ] \
+	[ "X$AUTH_TYPES" = X ] \
 		&& log_error "failed to get auth type"
-	log_debug "set_gfmd_params: set AUTH_TYPE=$AUTH_TYPE"
+	log_debug "set_gfmd_params: set AUTH_TYPE=$AUTH_TYPES"
 
 	[ "X$GFARM_CONF" = X ] \
 		&& log_error "failed to get gfarm client conf file"
@@ -805,7 +805,7 @@ subcmd_config_gfarm()
 	eval config-gfarm $CONFIG_GFARM_OPTIONS
 	[ $? -ne 0 ] && log_error "config-gfarm failed"
 
-	case $AUTH_TYPE in
+	case $AUTH_TYPES in
 	gsi|gsi_auth) set_conf $GFMD_CONF 'auth enable sharedsecret' '*';;
 	esac
 
@@ -830,7 +830,7 @@ subcmd_config_gfarm_master()
 	[ $? -ne 0 ] && log_error "config-gfarm failed"
 
 	unset_conf $GFMD_CONF metadb_server_force_slave
-	case $AUTH_TYPE in
+	case $AUTH_TYPES in
 	gsi|gsi_auth) set_conf $GFMD_CONF 'auth enable sharedsecret' '*';;
 	esac
 

--- a/util/gfservice/gfservice.in
+++ b/util/gfservice/gfservice.in
@@ -347,7 +347,7 @@ get_auth_type()
 	else
 		gfmd1_AUTH_TYPE=`@bindir@/config-gfarm -T \
 			$gfmd1_CONFIG_GFARM_OPTIONS \
-			| sed -ne '/^AUTH_TYPE=/s/^[^=]*=//p'`
+			| sed -ne '/^AUTH_TYPES=/s/^[^=]*=//p'`
 		[ "X$gfmd1_AUTH_TYPE" = X ] && gfmd1_AUTH_TYPE=sharedsecret
 		echo "$gfmd1_AUTH_TYPE"
 		log_debug "get_auth_type: AUTH_TYPE=$gfmd1_AUTH_TYPE"


### PR DESCRIPTION
After supporting multiple -a options in config-gfarm, AUTH_TYPE was renamed to AUTH_TYPES. Some references in gfservice remained unchanged, causing a regression.

This commit updates them accordingly.