### PR TITLE
config-gfarm: auto-detect client auth types via gfstatus -S

### DIFF
--- a/gftool/config-gfarm/config-gfarm.in
+++ b/gftool/config-gfarm/config-gfarm.in
@@ -475,7 +475,21 @@ fi
 : ${METADATA_ADMIN_USER:=`who am i | awk '{print $1}'`}
 : ${METADATA_ADMIN_USER_GSI_DN:=}
 
-: ${AUTH_TYPES:="sharedsecret"}
+: ${AUTH_TYPES:=""}
+if [ -z "$AUTH_TYPES" ]; then
+	AUTH=""
+	for a in $(gfstatus -S |
+	       awk '/^client auth/ && $0 !~ /not available/ {
+		      auth=$3; sub(/:/, "", auth); print auth }')
+	do
+		[ "$a" = gsi ] && AUTH="${AUTH:+$AUTH }gsi gsi_auth"
+		[ "$a" = tls ] && AUTH="${AUTH:+$AUTH }tls_sharedsecret tls_client_certificate"
+		[ "$a" = kerberos ] && AUTH="${AUTH:+$AUTH }kerberos kerberos_auth"
+		[ "$a" = sasl ] && AUTH="${AUTH:+$AUTH }sasl sasl_auth"
+	done
+
+	AUTH_TYPES="$AUTH sharedsecret"
+fi
 
 if $PRIVATE_MODE; then
 	: ${GFMD_PORT:="10601"}


### PR DESCRIPTION
Generate AUTH_TYPES dynamically based on available client authentication methods reported by gfstatus -S.
"sharedsecret" is appended as a fallback.

Automatic configuration of sasl_mechanism is not included yet.