### PR TITLE
gfservice-agent: remove failover-related config files in unconfig

### DIFF
--- a/util/gfservice/gfservice-agent.in
+++ b/util/gfservice/gfservice-agent.in
@@ -876,6 +876,8 @@ subcmd_unconfig_gfarm()
 	rm -f $GFMD_CONF
 	rm -f $GFMD_RC
 	rm -f $BACKEND_RC
+	rm -f $GFMD_FAILOVER_CONF
+	rm -f $GFMD_FAILOVER_AGENT_CONF
 	rm -f -r $METADATA_DIR
 	rm -f -r $JOURNAL_DIR
 	[ "X$GFSD_CONF" != X ] && rm -f $GFSD_CONF


### PR DESCRIPTION
In gfservice-agent.in, add removal of the following failover-related configuration files in subcmd_unconfig_gfarm():

  - $GFMD_FAILOVER_CONF
  - $GFMD_FAILOVER_AGENT_CONF

This prevents leftover failover configuration from persisting after unconfig.

This is a temporary workaround. The proper approach is to use @sysconfdir@/unconfig-gfarm.sh for cleanup.