### PR TITLE
gfservice: support multiple authentication methods via AUTH_TYPES

### DIFF
--- a/doc/docbook/en/ref/man1/gfservice.1.docbook
+++ b/doc/docbook/en/ref/man1/gfservice.1.docbook
@@ -5,7 +5,7 @@
 
 <refentry id="gfservice.1">
 
-<refentryinfo><date>6 Jun 2013</date></refentryinfo>
+<refentryinfo><date>17 Apr 2026</date></refentryinfo>
 
 <refmeta>
 <refentrytitle>gfservice</refentrytitle>
@@ -743,8 +743,8 @@ defined in the configuration file.
 It also updates <filename moreinfo="none">gfsd.conf</filename> file and distributes it to
 all gfmd and gfsd hosts, if "gfmd<replaceable>n</replaceable>_PRIVATE_MODE"
 variable is set to "true".
-If the value of the variable "gfmd<replaceable>n</replaceable>_AUTH_TYPE"
-is "sharedsecret", it also copies a shared key file from the maste gfmd
+If "sharedsecret" is included in the variable "gfmd<replaceable>n</replaceable>_AUTH_TYPES",
+it also copies a shared key file from the master gfmd
 to the slave gfmd host.
 </para>
 </listitem>
@@ -952,8 +952,8 @@ its value is passed to <command moreinfo="none">config-gfsd</command> command as
 options.
 <command moreinfo="none">gfservice</command> also registers the configured remote host
 as a filesystem node using <command moreinfo="none">gfhost</command> command.
-If the value of the variable "gfsd<replaceable>n</replaceable>_AUTH_TYPE"
-is "sharedsecret", it also copies a shared key file from gfmd1 to the
+If "sharedsecret" is included in the variable "gfsd<replaceable>n</replaceable>_AUTH_TYPES",
+it also copies a shared key file from gfmd1 to the
 gfsd host.
 </para>
 </listitem>
@@ -1136,8 +1136,8 @@ standard in.
 <para>
 Copy <filename moreinfo="none">gfarm2.conf</filename> file from gfmd1 to the client
 host.
-If the value of the variable "client<replaceable>n</replaceable>_AUTH_TYPE"
-is "sharedsecret", it also copies a shared key file from gfmd1 to the
+If "sharedsecret" is included in the variable "client<replaceable>n</replaceable>_AUTH_TYPES",
+it also copies a shared key file from gfmd1 to the
 client host.
 </para>
 </listitem>

--- a/doc/docbook/en/ref/man1/gfservice.1.docbook
+++ b/doc/docbook/en/ref/man1/gfservice.1.docbook
@@ -5,7 +5,7 @@
 
 <refentry id="gfservice.1">
 
-<refentryinfo><date>17 Apr 2026</date></refentryinfo>
+<refentryinfo><date>23 Apr 2026</date></refentryinfo>
 
 <refmeta>
 <refentrytitle>gfservice</refentrytitle>
@@ -743,7 +743,7 @@ defined in the configuration file.
 It also updates <filename moreinfo="none">gfsd.conf</filename> file and distributes it to
 all gfmd and gfsd hosts, if "gfmd<replaceable>n</replaceable>_PRIVATE_MODE"
 variable is set to "true".
-If "sharedsecret" is included in the variable "gfmd<replaceable>n</replaceable>_AUTH_TYPES",
+If "sharedsecret" or "tls_sharedsecret" is included in the variable "gfmd<replaceable>n</replaceable>_AUTH_TYPES",
 it also copies a shared key file from the master gfmd
 to the slave gfmd host.
 </para>
@@ -952,7 +952,7 @@ its value is passed to <command moreinfo="none">config-gfsd</command> command as
 options.
 <command moreinfo="none">gfservice</command> also registers the configured remote host
 as a filesystem node using <command moreinfo="none">gfhost</command> command.
-If "sharedsecret" is included in the variable "gfsd<replaceable>n</replaceable>_AUTH_TYPES",
+If "sharedsecret" or "tls_sharedsecret" is included in the variable "gfsd<replaceable>n</replaceable>_AUTH_TYPES",
 it also copies a shared key file from gfmd1 to the
 gfsd host.
 </para>
@@ -1136,7 +1136,7 @@ standard in.
 <para>
 Copy <filename moreinfo="none">gfarm2.conf</filename> file from gfmd1 to the client
 host.
-If "sharedsecret" is included in the variable "client<replaceable>n</replaceable>_AUTH_TYPES",
+If "sharedsecret" or "tls_sharedsecret" is included in the variable "client<replaceable>n</replaceable>_AUTH_TYPES",
 it also copies a shared key file from gfmd1 to the
 client host.
 </para>

--- a/doc/docbook/en/ref/man5/gfservice.conf.5.docbook
+++ b/doc/docbook/en/ref/man5/gfservice.conf.5.docbook
@@ -5,7 +5,7 @@
 
 <refentry id="gfservice.conf.5">
 
-<refentryinfo><date>25 Feb 2026</date></refentryinfo>
+<refentryinfo><date>17 Apr 2026</date></refentryinfo>
 
 <refmeta>
 <refentrytitle>gfservice.conf</refentrytitle>
@@ -177,10 +177,12 @@ in private mode.
 </varlistentry>
 
 <varlistentry>
-<term><varname>gfmd<replaceable>n</replaceable>_AUTH_TYPE</varname></term>
+<term><varname>gfmd<replaceable>n</replaceable>_AUTH_TYPES</varname></term>
 <listitem>
 <para>
-Specify authentication type ("sharedsecret", "gsi" or "gsi_auth").
+Specify authentication types ("sharedsecret", "sasl_auth", "sasl", "tls_sharedsecret",
+ "tls_client_certificate", "kerberos_auth", "kerberos", "gsi_auth", or "gsi")
+ as a space-separated string (e.g., "sharedsecret gsi").
 If the variable is not declared, its value is chosen from
 <varname>AUTH_TYPES</varname> value output by
 <command moreinfo="none">config-gfarm -T</command> command executed on gfmd1.
@@ -300,10 +302,12 @@ in private mode.
 </varlistentry>
 
 <varlistentry>
-<term><varname>gfsd<replaceable>n</replaceable>_AUTH_TYPE</varname></term>
+<term><varname>gfsd<replaceable>n</replaceable>_AUTH_TYPES</varname></term>
 <listitem>
 <para>
-Specify authentication type ("sharedsecret", "gsi" or "gsi_auth").
+Specify authentication types ("sharedsecret", "sasl_auth", "sasl", "tls_sharedsecret",
+ "tls_client_certificate", "kerberos_auth", "kerberos", "gsi_auth", or "gsi")
+ as a space-separated string (e.g., "sharedsecret gsi").
 If the variable is not declared, its value is chosen from
 <varname>AUTH_TYPES</varname> value output by
 <command moreinfo="none">config-gfarm -T</command> command executed on gfmd1.
@@ -453,10 +457,12 @@ the sub-command <command moreinfo="none">config-client</command> without root pr
 </varlistentry>
 
 <varlistentry>
-<term><varname>client<replaceable>n</replaceable>_AUTH_TYPE</varname></term>
+<term><varname>client<replaceable>n</replaceable>_AUTH_TYPES</varname></term>
 <listitem>
 <para>
-Specify authentication type ("sharedsecret", "gsi" or "gsi_auth").
+Specify authentication types ("sharedsecret", "sasl_auth", "sasl", "tls_sharedsecret",
+ "tls_client_certificate", "kerberos_auth", "kerberos", "gsi_auth", or "gsi")
+ as a space-separated string (e.g., "sharedsecret gsi").
 If the variable is not declared, its value is chosen from
 <varname>AUTH_TYPES</varname> value output by
 <command moreinfo="none">config-gfarm -T</command> command executed on gfmd1.

--- a/doc/docbook/en/ref/man5/gfservice.conf.5.docbook
+++ b/doc/docbook/en/ref/man5/gfservice.conf.5.docbook
@@ -160,6 +160,8 @@ Specify options of <command moreinfo="none">config-gfarm</command> command.
 The default value is empty (no option).
 <command moreinfo="none">gfservice</command> refers this variable to perform
 <command moreinfo="none">config-gfarm</command> and many other sub-commands.
+If only "sasl" is specified as the authentication type,
+"tls_client_certificate" will also be added as an authentication type to a gfarm2.conf file on all hosts.
 Do not delete or edit the declaration even after
 <command moreinfo="none">config-gfarm</command> has been complete.
 </para>

--- a/doc/docbook/ja/ref/man1/gfservice.1.docbook
+++ b/doc/docbook/ja/ref/man1/gfservice.1.docbook
@@ -5,7 +5,7 @@
 
 <refentry id="gfservice.1">
 
-<refentryinfo><date>17 Apr 2026</date></refentryinfo>
+<refentryinfo><date>23 Apr 2026</date></refentryinfo>
 
 <refmeta>
 <refentrytitle>gfservice</refentrytitle>
@@ -739,7 +739,7 @@ gfmd のレプリケーションが自動的に有効になります。
 変数「gfmd<replaceable>n</replaceable>_PRIVATE_MODE」の値が「true」に
 セットされている場合は、同様に <filename moreinfo="none">gfsd.conf</filename> ファイル
 を更新し、すべての gfmd ホストと gfsd ホストに配布します。
-変数「gfmd<replaceable>n</replaceable>_AUTH_TYPES」に「sharedsecret」が含まれている場合、
+変数「gfmd<replaceable>n</replaceable>_AUTH_TYPES」に「sharedsecret」ないし「tls_sharedsecret」が含まれている場合、
 共有秘密鍵ファイルをマスター gfmd ホストからこのスレーブ gfmd
 ホストへコピーします。
 </para>
@@ -949,7 +949,7 @@ gfmd 用の <command moreinfo="none">restore-usermap</command> サブコマン�
 その値が <command moreinfo="none">config-gfsd</command> にオプションとして付与されます。
 また、<command moreinfo="none">gfservice</command> は <command moreinfo="none">gfhost</command> コマンド
 を用いて、リモートホストをファイルシステムノードとして登録します。
-変数「gfsd<replaceable>n</replaceable>_AUTH_TYPES」に「sharedsecret」が含まれている場合、
+変数「gfsd<replaceable>n</replaceable>_AUTH_TYPES」に「sharedsecret」ないし「tls_sharedsecret」が含まれている場合、
 共有秘密鍵ファイルを gfmd1 から gfsd ホストへコピーします。
 </para>
 </listitem>
@@ -1130,7 +1130,7 @@ Gfarm2 ファイルシステムをアンマウントします。
 </term>
 <listitem>
 <para>
-変数「client<replaceable>n</replaceable>_AUTH_TYPES」に「sharedsecret」が含まれている場合、
+変数「client<replaceable>n</replaceable>_AUTH_TYPES」に「sharedsecret」ないし「tls_sharedsecret」が含まれている場合、
 共有秘密鍵ファイルを gfmd1 からクライアントホストへコピーします。
 </para>
 </listitem>

--- a/doc/docbook/ja/ref/man1/gfservice.1.docbook
+++ b/doc/docbook/ja/ref/man1/gfservice.1.docbook
@@ -5,7 +5,7 @@
 
 <refentry id="gfservice.1">
 
-<refentryinfo><date>15 Feb 2013</date></refentryinfo>
+<refentryinfo><date>17 Apr 2026</date></refentryinfo>
 
 <refmeta>
 <refentrytitle>gfservice</refentrytitle>
@@ -739,8 +739,8 @@ gfmd のレプリケーションが自動的に有効になります。
 変数「gfmd<replaceable>n</replaceable>_PRIVATE_MODE」の値が「true」に
 セットされている場合は、同様に <filename moreinfo="none">gfsd.conf</filename> ファイル
 を更新し、すべての gfmd ホストと gfsd ホストに配布します。
-変数「gfmd<replaceable>n</replaceable>_AUTH_TYPE」の値が「sharedsecret」
-の場合、共有秘密鍵ファイルをマスター gfmd ホストからこのスレーブ gfmd
+変数「gfmd<replaceable>n</replaceable>_AUTH_TYPES」に「sharedsecret」が含まれている場合、
+共有秘密鍵ファイルをマスター gfmd ホストからこのスレーブ gfmd
 ホストへコピーします。
 </para>
 </listitem>
@@ -949,8 +949,8 @@ gfmd 用の <command moreinfo="none">restore-usermap</command> サブコマン�
 その値が <command moreinfo="none">config-gfsd</command> にオプションとして付与されます。
 また、<command moreinfo="none">gfservice</command> は <command moreinfo="none">gfhost</command> コマンド
 を用いて、リモートホストをファイルシステムノードとして登録します。
-変数「gfsd<replaceable>n</replaceable>_AUTH_TYPE」の値が「sharedsecret」
-の場合、共有秘密鍵ファイルを gfmd1 から gfsd ホストへコピーします。
+変数「gfsd<replaceable>n</replaceable>_AUTH_TYPES」に「sharedsecret」が含まれている場合、
+共有秘密鍵ファイルを gfmd1 から gfsd ホストへコピーします。
 </para>
 </listitem>
 </varlistentry>
@@ -1130,8 +1130,8 @@ Gfarm2 ファイルシステムをアンマウントします。
 </term>
 <listitem>
 <para>
-変数「client<replaceable>n</replaceable>_AUTH_TYPE」の値が「sharedsecret」
-の場合、共有秘密鍵ファイルを gfmd1 からクライアントホストへコピーします。
+変数「client<replaceable>n</replaceable>_AUTH_TYPES」に「sharedsecret」が含まれている場合、
+共有秘密鍵ファイルを gfmd1 からクライアントホストへコピーします。
 </para>
 </listitem>
 </varlistentry>

--- a/doc/docbook/ja/ref/man5/gfservice.conf.5.docbook
+++ b/doc/docbook/ja/ref/man5/gfservice.conf.5.docbook
@@ -5,7 +5,7 @@
 
 <refentry id="gfservice.conf.5">
 
-<refentryinfo><date>25 Feb 2026</date></refentryinfo>
+<refentryinfo><date>17 Apr 2026</date></refentryinfo>
 
 <refmeta>
 <refentrytitle>gfservice.conf</refentrytitle>
@@ -177,10 +177,12 @@ gfmd サーバー上で <command moreinfo="none">gfservice-agent</command> コ�
 </varlistentry>
 
 <varlistentry>
-<term><varname>gfmd<replaceable>n</replaceable>_AUTH_TYPE</varname></term>
+<term><varname>gfmd<replaceable>n</replaceable>_AUTH_TYPES</varname></term>
 <listitem>
 <para>
-認証タイプ ("sharedsecret", "gsi", "gsi_auth" のいずれか) を指定します。
+認証タイプ ("sharedsecret", "sasl_auth", "sasl", "tls_sharedsecret",
+ "tls_client_certificate", "kerberos_auth", "kerberos", "gsi_auth",
+ または "gsi") を空白区切りの文字列で指定します。
 この変数が定義されていない場合は、gfmd1 上で
 <command moreinfo="none">config-gfarm -T</command> を実行したときの
 <varname>AUTH_TYPES</varname> の値が採用されます。
@@ -300,10 +302,12 @@ gfsd サーバー上で <command moreinfo="none">gfservice-agent</command> コ�
 </varlistentry>
 
 <varlistentry>
-<term><varname>gfsd<replaceable>n</replaceable>_AUTH_TYPE</varname></term>
+<term><varname>gfsd<replaceable>n</replaceable>_AUTH_TYPES</varname></term>
 <listitem>
 <para>
-認証タイプ ("sharedsecret", "gsi", "gsi_auth" のいずれか) を指定します。
+認証タイプ ("sharedsecret", "sasl_auth", "sasl", "tls_sharedsecret",
+ "tls_client_certificate", "kerberos_auth", "kerberos", "gsi_auth",
+ または "gsi") を空白区切りの文字列で指定します。
 この変数が定義されていない場合は、gfmd1 上で
 <command moreinfo="none">config-gfarm -T</command> を実行したときの
 <varname>AUTH_TYPES</varname> の値が採用されます。
@@ -455,10 +459,12 @@ gfarm2.confファイルのパスと同じパスを使用します(gfarm2.confフ
 </varlistentry>
 
 <varlistentry>
-<term><varname>client<replaceable>n</replaceable>_AUTH_TYPE</varname></term>
+<term><varname>client<replaceable>n</replaceable>_AUTH_TYPES</varname></term>
 <listitem>
 <para>
-認証タイプ ("sharedsecret", "gsi", "gsi_auth" のいずれか) を指定します。
+認証タイプ ("sharedsecret", "sasl_auth", "sasl", "tls_sharedsecret",
+ "tls_client_certificate", "kerberos_auth", "kerberos", "gsi_auth",
+ または "gsi") を空白区切りの文字列で指定します。
 この変数が定義されていない場合は、gfmd1 上で
 <command moreinfo="none">config-gfarm -T</command> を実行したときの
 <varname>AUTH_TYPES</varname> の値が採用されます。

--- a/doc/docbook/ja/ref/man5/gfservice.conf.5.docbook
+++ b/doc/docbook/ja/ref/man5/gfservice.conf.5.docbook
@@ -160,6 +160,8 @@ gfmd サーバー上で <command moreinfo="none">gfservice-agent</command> コ�
 デフォルト値は、空文字列 (オプションなし) です。
 <command moreinfo="none">gfservice</command> は <command moreinfo="none">config-gfarm</command> サブコマンド
 およびその他多くのサブコマンドを実行する際に、この変数を参照します。
+認証タイプとして "sasl" のみが指定されている場合、全てのホストのgfarm2.confファイルに
+"tls_client_certificate" も認証タイプとして追加されます。
 <command moreinfo="none">config-gfarm</command> が完了した後であっても、この変数の宣言を
 削除したり、編集したりはしないで下さい。
 </para>

--- a/docker/dev/common/gen.sh
+++ b/docker/dev/common/gen.sh
@@ -53,7 +53,10 @@ EOF
     gfmd="${GFDOCKER_HOSTNAME_PREFIX_GFMD}${i}"
     cat <<EOF
 
-## if *_AUTH_TYPES contain sharedsecret, ~/.gfarm_shared_key can copied
+## if *_AUTH_TYPES contain sharedsecret or tls_sharedsecret,
+## ~/.gfarm_shared_key can be copied
+## if only sasl is specified by -a option of *_CONFIG_GFARM_OPTIONS,
+## tls_client_certificate will also be added to gfarm2.conf on all hosts
 
 ##
 ## gfmd ${i}

--- a/docker/dev/common/gen.sh
+++ b/docker/dev/common/gen.sh
@@ -53,14 +53,14 @@ EOF
     gfmd="${GFDOCKER_HOSTNAME_PREFIX_GFMD}${i}"
     cat <<EOF
 
-## *_AUTH_TYPE=sharedsecret can copy ~/.gfarm_shared_key
+## if *_AUTH_TYPES contain sharedsecret, ~/.gfarm_shared_key can copied
 
 ##
 ## gfmd ${i}
 ##
 gfmd${i}=${gfmd}${GFDOCKER_HOSTNAME_SUFFIX}
 ${gfmd}_CONFIG_GFARM_OPTIONS="-r -j ${GFDOCKER_GFMD_JOURNAL_DIR} -X -A \$LOGNAME -h \$gfmd${i} -a ${GFDOCKER_AUTH_TYPE} -D ${ADMIN_DN}"
-gfmd${i}_AUTH_TYPE=sharedsecret
+gfmd${i}_AUTH_TYPES=sharedsecret
 EOF
   done
 
@@ -74,7 +74,7 @@ EOF
 ##
 gfsd${i}=${gfsd}${GFDOCKER_HOSTNAME_SUFFIX}
 gfsd${i}_CONFIG_GFSD_OPTIONS="-h \$gfsd${i} -l \$gfsd${i} -a ${GFDOCKER_PRJ_NAME}"
-gfsd${i}_AUTH_TYPE=sharedsecret
+gfsd${i}_AUTH_TYPES=sharedsecret
 EOF
   done
 
@@ -87,7 +87,7 @@ EOF
 ## client ${i}
 ##
 client${i}=${client}${GFDOCKER_HOSTNAME_SUFFIX}
-client${i}_AUTH_TYPE=sharedsecret
+client${i}_AUTH_TYPES=sharedsecret
 EOF
   done
 }

--- a/gftool/config-gfarm/config-gfarm.in
+++ b/gftool/config-gfarm/config-gfarm.in
@@ -244,7 +244,7 @@ display_script_params()
     display_script_params_backend_port_$BACKEND_TYPE
 
     echo     "GFMD_PORT=$GFMD_PORT"
-    echo     "AUTH_TYPES=$AUTH_TYPES"
+    echo     "AUTH_TYPES='$AUTH_TYPES'"
 
     display_script_params_backend_optional_$BACKEND_TYPE
 
@@ -488,7 +488,7 @@ if [ -z "$AUTH_TYPES" ]; then
 		[ "$a" = sasl ] && AUTH="${AUTH:+$AUTH }sasl sasl_auth"
 	done
 
-	AUTH_TYPES="$AUTH sharedsecret"
+	AUTH_TYPES="${AUTH:+$AUTH }sharedsecret"
 fi
 
 if $PRIVATE_MODE; then

--- a/util/gfservice/gfservice-agent.in
+++ b/util/gfservice/gfservice-agent.in
@@ -136,7 +136,7 @@ set_gfmd_params()
 
 	[ "X$AUTH_TYPES" = X ] \
 		&& log_error "failed to get auth type"
-	log_debug "set_gfmd_params: set AUTH_TYPE=$AUTH_TYPES"
+	log_debug "set_gfmd_params: set AUTH_TYPES=$AUTH_TYPES"
 
 	[ "X$GFARM_CONF" = X ] \
 		&& log_error "failed to get gfarm client conf file"
@@ -808,9 +808,13 @@ subcmd_config_gfarm()
 	eval config-gfarm $CONFIG_GFARM_OPTIONS
 	[ $? -ne 0 ] && log_error "config-gfarm failed"
 
-	case $AUTH_TYPES in
-	gsi|gsi_auth) set_conf $GFMD_CONF 'auth enable sharedsecret' '*';;
-	esac
+	for t in $AUTH_TYPES; do
+		case $t in
+		gsi|gsi_auth)
+			set_conf $GFMD_CONF 'auth enable sharedsecret' '*'
+			;;
+		esac
+	done
 
 	TIMEOUT=`get_param timeout || echo 'no'`
 	stop_gfmd $TIMEOUT
@@ -833,9 +837,13 @@ subcmd_config_gfarm_master()
 	[ $? -ne 0 ] && log_error "config-gfarm failed"
 
 	unset_conf $GFMD_CONF metadb_server_force_slave
-	case $AUTH_TYPES in
-	gsi|gsi_auth) set_conf $GFMD_CONF 'auth enable sharedsecret' '*';;
-	esac
+	for t in $AUTH_TYPES; do
+		case $t in
+		gsi|gsi_auth)
+			set_conf $GFMD_CONF 'auth enable sharedsecret' '*'
+			;;
+		esac
+	done
 
 	set_conf $GFARM_CONF metadb_server_list \
 		"${BACKEND_HOSTNAME}:${GFMD_PORT}"

--- a/util/gfservice/gfservice-agent.in
+++ b/util/gfservice/gfservice-agent.in
@@ -808,13 +808,22 @@ subcmd_config_gfarm()
 	eval config-gfarm $CONFIG_GFARM_OPTIONS
 	[ $? -ne 0 ] && log_error "config-gfarm failed"
 
+	only_sasl=true
 	for t in $AUTH_TYPES; do
 		case $t in
-		gsi|gsi_auth)
-			set_conf $GFMD_CONF 'auth enable sharedsecret' '*'
+		sasl|sasl_auth)
+			;;
+		*)
+			only_sasl=false
 			;;
 		esac
 	done
+
+	# Enable TLS client certificate authentication if only SASL is used
+	if $only_sasl; then
+		set_conf "$GFMD_CONF" 'auth enable tls_client_certificate' '*'
+		set_conf "$GFARM_CONF" 'auth enable tls_client_certificate' '*'
+	fi
 
 	TIMEOUT=`get_param timeout || echo 'no'`
 	stop_gfmd $TIMEOUT
@@ -837,13 +846,22 @@ subcmd_config_gfarm_master()
 	[ $? -ne 0 ] && log_error "config-gfarm failed"
 
 	unset_conf $GFMD_CONF metadb_server_force_slave
+	only_sasl=true
 	for t in $AUTH_TYPES; do
 		case $t in
-		gsi|gsi_auth)
-			set_conf $GFMD_CONF 'auth enable sharedsecret' '*'
+		sasl|sasl_auth)
+			;;
+		*)
+			only_sasl=false
 			;;
 		esac
 	done
+
+	# Enable TLS client certificate authentication if only SASL is used
+	if $only_sasl; then
+		set_conf "$GFMD_CONF" 'auth enable tls_client_certificate' '*'
+		set_conf "$GFARM_CONF" 'auth enable tls_client_certificate' '*'
+	fi
 
 	set_conf $GFARM_CONF metadb_server_list \
 		"${BACKEND_HOSTNAME}:${GFMD_PORT}"

--- a/util/gfservice/gfservice.in
+++ b/util/gfservice/gfservice.in
@@ -333,27 +333,27 @@ get_config_gfsd_options()
 #
 # Get authenticatoin type of a host ID.
 #
-get_auth_type()
+get_auth_types()
 {
-	log_debug "get_auth_type: HOSTID=$1"
+	log_debug "get_auth_types: HOSTID=$1"
 
-	if [ "X`eval echo \\$$1_AUTH_TYPE`" != X ]; then
-		eval echo "\$$1_AUTH_TYPE"
-		log_debug "get_auth_type:" \
-			"AUTH_TYPE="`eval echo \\$$1_AUTH_TYPE`
-	elif [ "X$gfmd1_AUTH_TYPE" != X ]; then
-		echo "$gfmd1_AUTH_TYPE"
-		log_debug "get_auth_type: AUTH_TYPE=$gfmd1_AUTH_TYPE"
+	if [ "X`eval echo \\$$1_AUTH_TYPES`" != X ]; then
+		eval echo "\$$1_AUTH_TYPES"
+		log_debug "get_auth_types:" \
+			"AUTH_TYPES="`eval echo \\$$1_AUTH_TYPES`
+	elif [ "X$gfmd1_AUTH_TYPES" != X ]; then
+		echo "$gfmd1_AUTH_TYPES"
+		log_debug "get_auth_types: AUTH_TYPES=$gfmd1_AUTH_TYPES"
 	else
-		gfmd1_AUTH_TYPE=`@bindir@/config-gfarm -T \
+		gfmd1_AUTH_TYPES=`@bindir@/config-gfarm -T \
 			$gfmd1_CONFIG_GFARM_OPTIONS \
 			| sed -ne '/^AUTH_TYPES=/s/^[^=]*=//p'`
-		[ "X$gfmd1_AUTH_TYPE" = X ] && gfmd1_AUTH_TYPE=sharedsecret
-		echo "$gfmd1_AUTH_TYPE"
-		log_debug "get_auth_type: AUTH_TYPE=$gfmd1_AUTH_TYPE"
+		[ "X$gfmd1_AUTH_TYPES" = X ] && gfmd1_AUTH_TYPES=sharedsecret
+		echo "$gfmd1_AUTH_TYPES"
+		log_debug "get_auth_types: AUTH_TYPES=$gfmd1_AUTH_TYPES"
 	fi
 
-	log_debug "end get_auth_type"
+	log_debug "end get_auth_types"
 }
 
 #
@@ -764,9 +764,19 @@ copy_gfarm_conf()
 		[ $? -ne 0 ] && log_error \
 			"gfservice-agent backup-gfarm-conf $1 failed"
 	fi
-	# if AUTH_TYPE is gsi*, this is necessary, and harmless if sharedsecret
+	# if any AUTH_TYPES contains gsi*, this is necessary, and harmless if sharedsecret
 	case $2 in
-	gfsd*) echo 'auth enable sharedsecret *' >> $TMP_FILE;;
+	gfsd*)
+		eval AUTH_TYPES=$(get_auth_types $2)
+		for t in $AUTH_TYPES; do
+			case $t in
+			gsi|gsi_auth)
+				sed -e '/^auth enable sharedsecret /d' $TMP_FILE > $TMP_FILE.tmp
+				echo 'auth enable sharedsecret *' >> $TMP_FILE.tmp
+				mv $TMP_FILE.tmp $TMP_FILE
+				;;
+			esac
+		done
 	esac
 
 	exec_remote_host_agent $2 root restore-gfarm-conf < $TMP_FILE
@@ -1574,8 +1584,14 @@ subcmd_config_gfarm_slave()
 	#
 	# Copy a shared secret key from the master gfmd host to the slave.
 	#
-	[ "X`get_auth_type $HOSTID`" = Xsharedsecret ] \
-		&& copy_shared_key $MASTER_HOSTID $HOSTID
+	eval AUTH_TYPES=$(get_auth_types $HOSTID)
+	for t in $AUTH_TYPES; do
+		case $t in
+			sharedsecret)
+				copy_shared_key $MASTER_HOSTID $HOSTID
+				;;
+		esac
+	done
 
 	#
 	# Copy PostgreSQL database from the master gfmd host to the slave.
@@ -1631,8 +1647,14 @@ subcmd_config_gfsd()
 	#
 	# Copy a shared secret key from $MASTER_HOSTID to the gfsd host.
 	#
-	[ "X`get_auth_type $HOSTID`" = Xsharedsecret ] \
-		&& copy_shared_key $MASTER_HOSTID $HOSTID
+	eval AUTH_TYPES=$(get_auth_types $HOSTID)
+	for t in $AUTH_TYPES; do
+		case $t in
+			sharedsecret)
+				copy_shared_key $MASTER_HOSTID $HOSTID
+				;;
+		esac
+	done
 
 	#
 	# Copy 'gfarm2.conf' from $MASTER_HOSTID to the gfsd host.
@@ -1688,8 +1710,14 @@ subcmd_config_client()
 	#
 	# Copy a shared secret key from $MASTER_HOSTID to the client host.
 	#
-	[ "X`get_auth_type $HOSTID`" = Xsharedsecret ] \
-		&& copy_shared_key $MASTER_HOSTID $HOSTID
+	eval AUTH_TYPES=$(get_auth_types $HOSTID)
+	for t in $AUTH_TYPES; do
+		case $t in
+			sharedsecret)
+				copy_shared_key $MASTER_HOSTID $HOSTID
+				;;
+		esac
+	done
 
 	#
 	# Copy 'gfarm2.conf' from $MASTER_HOSTID to the client host.

--- a/util/gfservice/gfservice.in
+++ b/util/gfservice/gfservice.in
@@ -764,20 +764,6 @@ copy_gfarm_conf()
 		[ $? -ne 0 ] && log_error \
 			"gfservice-agent backup-gfarm-conf $1 failed"
 	fi
-	# if any AUTH_TYPES contains gsi*, this is necessary, and harmless if sharedsecret
-	case $2 in
-	gfsd*)
-		eval AUTH_TYPES=$(get_auth_types $2)
-		for t in $AUTH_TYPES; do
-			case $t in
-			gsi|gsi_auth)
-				sed -e '/^auth enable sharedsecret /d' $TMP_FILE > $TMP_FILE.tmp
-				echo 'auth enable sharedsecret *' >> $TMP_FILE.tmp
-				mv $TMP_FILE.tmp $TMP_FILE
-				;;
-			esac
-		done
-	esac
 
 	exec_remote_host_agent $2 root restore-gfarm-conf < $TMP_FILE
 	[ $? -ne 0 ] && log_error \
@@ -1587,7 +1573,7 @@ subcmd_config_gfarm_slave()
 	eval AUTH_TYPES=$(get_auth_types $HOSTID)
 	for t in $AUTH_TYPES; do
 		case $t in
-			sharedsecret)
+			sharedsecret|tls_sharedsecret)
 				copy_shared_key $MASTER_HOSTID $HOSTID
 				;;
 		esac
@@ -1650,7 +1636,7 @@ subcmd_config_gfsd()
 	eval AUTH_TYPES=$(get_auth_types $HOSTID)
 	for t in $AUTH_TYPES; do
 		case $t in
-			sharedsecret)
+			sharedsecret|tls_sharedsecret)
 				copy_shared_key $MASTER_HOSTID $HOSTID
 				;;
 		esac
@@ -1713,7 +1699,7 @@ subcmd_config_client()
 	eval AUTH_TYPES=$(get_auth_types $HOSTID)
 	for t in $AUTH_TYPES; do
 		case $t in
-			sharedsecret)
+			sharedsecret|tls_sharedsecret)
 				copy_shared_key $MASTER_HOSTID $HOSTID
 				;;
 		esac


### PR DESCRIPTION
#1174 (Support multiple authentication methods via AUTH_TYPES)
Refs #1174

Replace AUTH_TYPE with AUTH_TYPES across gfservice and related tools,
allowing multiple authentication methods to be specified as a space-separated string.

Additionally, implement the remaining behaviors described in the issue:

- support tls_sharedsecret for shared key distribution
- enable tls_client_certificate automatically when only SASL-based methods are specified
- remove implicit sharedsecret behavior previously applied for gsi/gsi_auth

Update docbook to reflect AUTH_TYPES and clarify the authentication behavior.

This change covers both the introduction of AUTH_TYPES and the related
authentication handling described in the issue.