### PR TITLE
gfservice: add --quiet to unconfig-gfsd and suppress unnecessary hints

### DIFF
--- a/gftool/config-gfarm/unconfig-gfsd.sh.in
+++ b/gftool/config-gfarm/unconfig-gfsd.sh.in
@@ -99,7 +99,7 @@ service_unconfig()
 			$prefix/bin/gfhost -d "$GFSD_HOSTNAME"
 		fi
 	else
-		if [ ! "$QUIET" ]; then
+		if ! $QUIET; then
 			echo Please execute the following command on your host:
 			echo
 			echo "$prefix/bin/gfhost -d $GFSD_HOSTNAME"
@@ -109,7 +109,7 @@ service_unconfig()
 
 	if [ -f "$GFMD_CONF" ]; then
 		if [ X"$TEST_OPT" = "X-n" ]; then
-			if [ ! "$QUIET" ]; then
+			if ! $QUIET; then
 				echo
 				echo "The following files will not be deleted, because also gfmd has been configured:"
 				echo "  $GFARM_CONF"

--- a/gftool/config-gfarm/unconfig-gfsd.sh.in
+++ b/gftool/config-gfarm/unconfig-gfsd.sh.in
@@ -8,6 +8,7 @@ PROGNAME=`basename $0`
 awk=awk
 if [ -f /usr/bin/nawk ]; then awk=/usr/bin/nawk; fi
 
+: ${QUIET:=false}
 : ${FORCE:=false}
 : ${DRYRUN:=false}
 
@@ -37,7 +38,7 @@ fi
 
 usage()
 {
-        echo >&2 "usage: $PROGNAME [--help] [-f] [-t]"
+        echo >&2 "usage: $PROGNAME [--help] [--quiet] [-f] [-t]"
         exit 1
 }
 
@@ -51,6 +52,9 @@ parse_arguments()
 		# control options
 		  --help)
 			usage
+			;;
+		  --quiet)
+			QUIET=true
 			;;
 		  -t)
 			DRYRUN=true
@@ -95,20 +99,24 @@ service_unconfig()
 			$prefix/bin/gfhost -d "$GFSD_HOSTNAME"
 		fi
 	else
-		echo Please execute the following command on your host:
-		echo
-		echo "$prefix/bin/gfhost -d $GFSD_HOSTNAME"
-		echo
+		if [ ! "$QUIET" ]; then
+			echo Please execute the following command on your host:
+			echo
+			echo "$prefix/bin/gfhost -d $GFSD_HOSTNAME"
+			echo
+		fi
 	fi
 
 	if [ -f "$GFMD_CONF" ]; then
 		if [ X"$TEST_OPT" = "X-n" ]; then
-			echo
-			echo "The following files will not be deleted, because also gfmd has been configured:"
-			echo "  $GFARM_CONF"
-			echo "  $USERMAP_FILE"
-			if $PRIVATE_MODE; then
-				echo "  $GFARM_CLIENT_CONF"
+			if [ ! "$QUIET" ]; then
+				echo
+				echo "The following files will not be deleted, because also gfmd has been configured:"
+				echo "  $GFARM_CONF"
+				echo "  $USERMAP_FILE"
+				if $PRIVATE_MODE; then
+					echo "  $GFARM_CLIENT_CONF"
+				fi
 			fi
 		fi
 	else

--- a/util/gfservice/gfservice-agent.in
+++ b/util/gfservice/gfservice-agent.in
@@ -920,7 +920,7 @@ subcmd_unconfig_gfsd()
 	else
 		: ${GFARM_CONF_DIR:="$sysconfdir"}
 	fi
-	"$GFARM_CONF_DIR/unconfig-gfsd.sh" -f
+	"$GFARM_CONF_DIR/unconfig-gfsd.sh" -f --quiet
 
 	log_debug "end subcmd_unconfig_gfsd"
 }

--- a/util/gfservice/gfservice.in
+++ b/util/gfservice/gfservice.in
@@ -1742,7 +1742,7 @@ subcmd_config_all()
 			|| log_warn "failed to config-client for $HOSTID"
 	done
 
-        log_debug "end subcmd_config_all"
+    log_debug "end subcmd_config_all"
 }
 
 #
@@ -1876,7 +1876,7 @@ subcmd_unconfig_all()
 			|| log_warn "failed to unconfig-gfarm for $HOSTID"
 	done
 
-        log_debug "end subcmd_unconfig_all"
+	log_debug "end subcmd_unconfig_all"
 }
 
 #


### PR DESCRIPTION
Suppress hint messages in unconfig-gfsd.sh by introducing --quiet option. gfservice-agent uses this option to avoid redundant output during unconfig.

Hints are suppressed by --quiet, while interactive prompts (e.g. without -f) are still shown. Outputs required for DRYRUN (-t) are not suppressed. Errors are always printed.