### PR TITLE
doc: update AUTH_TYPES descriptions and improve make behavior

### DIFF
--- a/doc/docbook/en/ref/man5/gfservice.conf.5.docbook
+++ b/doc/docbook/en/ref/man5/gfservice.conf.5.docbook
@@ -5,7 +5,7 @@
 
 <refentry id="gfservice.conf.5">
 
-<refentryinfo><date>17 Apr 2026</date></refentryinfo>
+<refentryinfo><date>12 May 2026</date></refentryinfo>
 
 <refmeta>
 <refentrytitle>gfservice.conf</refentrytitle>
@@ -182,14 +182,11 @@ in private mode.
 <term><varname>gfmd<replaceable>n</replaceable>_AUTH_TYPES</varname></term>
 <listitem>
 <para>
-Specify authentication types ("sharedsecret", "sasl_auth", "sasl", "tls_sharedsecret",
- "tls_client_certificate", "kerberos_auth", "kerberos", "gsi_auth", or "gsi")
- as a space-separated string (e.g., "sharedsecret gsi").
-If the variable is not declared, its value is chosen from
-<varname>AUTH_TYPES</varname> value output by
-<command moreinfo="none">config-gfarm -T</command> command executed on gfmd1.
-(Note that the value <varname>AUTH_TYPES</varname> above is affected by
-the variable <varname>gfmd1_CONFIG_GFARM_OPTIONS</varname>.)
+This is used to control whether a shared key file is copied to client hosts.
+If <varname>gfmd1_CONFIG_GFARM_OPTIONS</varname> contains either "sharedsecret" or "tls_sharedsecret",
+the shared key file will be copied without any additional configuration.
+If neither is specified, the behavior is determined by the value of <varname>AUTH_TYPES</varname>
+output by the <command moreinfo="none">config-gfarm -T</command> command executed on gfmd1.
 </para>
 </listitem>
 </varlistentry>
@@ -307,14 +304,11 @@ in private mode.
 <term><varname>gfsd<replaceable>n</replaceable>_AUTH_TYPES</varname></term>
 <listitem>
 <para>
-Specify authentication types ("sharedsecret", "sasl_auth", "sasl", "tls_sharedsecret",
- "tls_client_certificate", "kerberos_auth", "kerberos", "gsi_auth", or "gsi")
- as a space-separated string (e.g., "sharedsecret gsi").
-If the variable is not declared, its value is chosen from
-<varname>AUTH_TYPES</varname> value output by
-<command moreinfo="none">config-gfarm -T</command> command executed on gfmd1.
-(Note that the value <varname>AUTH_TYPES</varname> above is affected by
-the variable <varname>gfmd1_CONFIG_GFARM_OPTIONS</varname>.)
+This is used to control whether a shared key file is copied to client hosts.
+If <varname>gfmd1_CONFIG_GFARM_OPTIONS</varname> contains either "sharedsecret" or "tls_sharedsecret",
+the shared key file will be copied without any additional configuration.
+If neither is specified, the behavior is determined by the value of <varname>AUTH_TYPES</varname>
+output by the <command moreinfo="none">config-gfarm -T</command> command executed on gfmd1.
 </para>
 </listitem>
 </varlistentry>
@@ -462,14 +456,11 @@ the sub-command <command moreinfo="none">config-client</command> without root pr
 <term><varname>client<replaceable>n</replaceable>_AUTH_TYPES</varname></term>
 <listitem>
 <para>
-Specify authentication types ("sharedsecret", "sasl_auth", "sasl", "tls_sharedsecret",
- "tls_client_certificate", "kerberos_auth", "kerberos", "gsi_auth", or "gsi")
- as a space-separated string (e.g., "sharedsecret gsi").
-If the variable is not declared, its value is chosen from
-<varname>AUTH_TYPES</varname> value output by
-<command moreinfo="none">config-gfarm -T</command> command executed on gfmd1.
-(Note that the value <varname>AUTH_TYPES</varname> above is affected by
-the variable <varname>gfmd1_CONFIG_GFARM_OPTIONS</varname>.)
+This is used to control whether a shared key file is copied to client hosts.
+If <varname>gfmd1_CONFIG_GFARM_OPTIONS</varname> contains either "sharedsecret" or "tls_sharedsecret",
+the shared key file will be copied without any additional configuration.
+If neither is specified, the behavior is determined by the value of <varname>AUTH_TYPES</varname>
+output by the <command moreinfo="none">config-gfarm -T</command> command executed on gfmd1.
 </para>
 </listitem>
 </varlistentry>

--- a/doc/docbook/en/ref/man5/gfservice.conf.5.docbook
+++ b/doc/docbook/en/ref/man5/gfservice.conf.5.docbook
@@ -5,7 +5,7 @@
 
 <refentry id="gfservice.conf.5">
 
-<refentryinfo><date>12 May 2026</date></refentryinfo>
+<refentryinfo><date>14 May 2026</date></refentryinfo>
 
 <refmeta>
 <refentrytitle>gfservice.conf</refentrytitle>
@@ -182,6 +182,9 @@ in private mode.
 <term><varname>gfmd<replaceable>n</replaceable>_AUTH_TYPES</varname></term>
 <listitem>
 <para>
+Specify authentication types ("sharedsecret", "sasl_auth", "sasl", "tls_sharedsecret",
+"tls_client_certificate", "kerberos_auth", "kerberos", "gsi_auth", or "gsi")
+as a space-separated string (e.g., "sharedsecret gsi").
 This is used to control whether a shared key file is copied to this gfmd host.
 If <varname>gfmd1_CONFIG_GFARM_OPTIONS</varname> contains either "sharedsecret" or "tls_sharedsecret",
 the shared key file will be copied without any additional configuration.
@@ -304,6 +307,9 @@ in private mode.
 <term><varname>gfsd<replaceable>n</replaceable>_AUTH_TYPES</varname></term>
 <listitem>
 <para>
+Specify authentication types ("sharedsecret", "sasl_auth", "sasl", "tls_sharedsecret",
+"tls_client_certificate", "kerberos_auth", "kerberos", "gsi_auth", or "gsi")
+as a space-separated string (e.g., "sharedsecret gsi").
 This is used to control whether a shared key file is copied to this gfsd host.
 If <varname>gfmd1_CONFIG_GFARM_OPTIONS</varname> contains either "sharedsecret" or "tls_sharedsecret",
 the shared key file will be copied without any additional configuration.
@@ -456,6 +462,9 @@ the sub-command <command moreinfo="none">config-client</command> without root pr
 <term><varname>client<replaceable>n</replaceable>_AUTH_TYPES</varname></term>
 <listitem>
 <para>
+Specify authentication types ("sharedsecret", "sasl_auth", "sasl", "tls_sharedsecret",
+"tls_client_certificate", "kerberos_auth", "kerberos", "gsi_auth", or "gsi")
+as a space-separated string (e.g., "sharedsecret gsi").
 This is used to control whether a shared key file is copied to this client host.
 If <varname>gfmd1_CONFIG_GFARM_OPTIONS</varname> contains either "sharedsecret" or "tls_sharedsecret",
 the shared key file will be copied without any additional configuration.

--- a/doc/docbook/en/ref/man5/gfservice.conf.5.docbook
+++ b/doc/docbook/en/ref/man5/gfservice.conf.5.docbook
@@ -182,7 +182,7 @@ in private mode.
 <term><varname>gfmd<replaceable>n</replaceable>_AUTH_TYPES</varname></term>
 <listitem>
 <para>
-This is used to control whether a shared key file is copied to client hosts.
+This is used to control whether a shared key file is copied to this gfmd host.
 If <varname>gfmd1_CONFIG_GFARM_OPTIONS</varname> contains either "sharedsecret" or "tls_sharedsecret",
 the shared key file will be copied without any additional configuration.
 If neither is specified, the behavior is determined by the value of <varname>AUTH_TYPES</varname>
@@ -304,7 +304,7 @@ in private mode.
 <term><varname>gfsd<replaceable>n</replaceable>_AUTH_TYPES</varname></term>
 <listitem>
 <para>
-This is used to control whether a shared key file is copied to client hosts.
+This is used to control whether a shared key file is copied to this gfsd host.
 If <varname>gfmd1_CONFIG_GFARM_OPTIONS</varname> contains either "sharedsecret" or "tls_sharedsecret",
 the shared key file will be copied without any additional configuration.
 If neither is specified, the behavior is determined by the value of <varname>AUTH_TYPES</varname>
@@ -456,7 +456,7 @@ the sub-command <command moreinfo="none">config-client</command> without root pr
 <term><varname>client<replaceable>n</replaceable>_AUTH_TYPES</varname></term>
 <listitem>
 <para>
-This is used to control whether a shared key file is copied to client hosts.
+This is used to control whether a shared key file is copied to this client host.
 If <varname>gfmd1_CONFIG_GFARM_OPTIONS</varname> contains either "sharedsecret" or "tls_sharedsecret",
 the shared key file will be copied without any additional configuration.
 If neither is specified, the behavior is determined by the value of <varname>AUTH_TYPES</varname>

--- a/doc/docbook/ja/ref/man5/gfservice.conf.5.docbook
+++ b/doc/docbook/ja/ref/man5/gfservice.conf.5.docbook
@@ -182,7 +182,7 @@ gfmd サーバー上で <command moreinfo="none">gfservice-agent</command> コ�
 <term><varname>gfmd<replaceable>n</replaceable>_AUTH_TYPES</varname></term>
 <listitem>
 <para>
-クライアントホストに共有鍵秘密ファイルをコピーするかどうかを制御するために使用します。
+この gfmd ホストに共有鍵秘密ファイルをコピーするかどうかを制御するために使用します。
 <varname> gfmd1_CONFIG_GFARM_OPTIONS </varname> に "sharedsecret"ないし "tls_sharedsecret" があれば
 特に設定しなくても共有鍵秘密ファイルがコピーされます。
 どちらの設定もなければ、gfmd1 上で <command moreinfo="none"> config-gfarm -T </command> を実行したときの
@@ -304,7 +304,7 @@ gfsd サーバー上で <command moreinfo="none">gfservice-agent</command> コ�
 <term><varname>gfsd<replaceable>n</replaceable>_AUTH_TYPES</varname></term>
 <listitem>
 <para>
-クライアントホストに共有鍵秘密ファイルをコピーするかどうかを制御するために使用します。
+この gfsd ホストに共有鍵秘密ファイルをコピーするかどうかを制御するために使用します。
 <varname> gfmd1_CONFIG_GFARM_OPTIONS </varname> に "sharedsecret"ないし "tls_sharedsecret" があれば
 特に設定しなくても共有鍵秘密ファイルがコピーされます。
 どちらの設定もなければ、gfmd1 上で <command moreinfo="none"> config-gfarm -T </command> を実行したときの
@@ -458,7 +458,7 @@ gfarm2.confファイルのパスと同じパスを使用します(gfarm2.confフ
 <term><varname>client<replaceable>n</replaceable>_AUTH_TYPES</varname></term>
 <listitem>
 <para>
-クライアントホストに共有鍵秘密ファイルをコピーするかどうかを制御するために使用します。
+このクライアントホストに共有鍵秘密ファイルをコピーするかどうかを制御するために使用します。
 <varname> gfmd1_CONFIG_GFARM_OPTIONS </varname> に "sharedsecret"ないし "tls_sharedsecret" があれば
 特に設定しなくても共有鍵秘密ファイルがコピーされます。
 どちらの設定もなければ、gfmd1 上で <command moreinfo="none"> config-gfarm -T </command> を実行したときの

--- a/doc/docbook/ja/ref/man5/gfservice.conf.5.docbook
+++ b/doc/docbook/ja/ref/man5/gfservice.conf.5.docbook
@@ -5,7 +5,7 @@
 
 <refentry id="gfservice.conf.5">
 
-<refentryinfo><date>17 Apr 2026</date></refentryinfo>
+<refentryinfo><date>12 May 2026</date></refentryinfo>
 
 <refmeta>
 <refentrytitle>gfservice.conf</refentrytitle>
@@ -182,14 +182,11 @@ gfmd サーバー上で <command moreinfo="none">gfservice-agent</command> コ�
 <term><varname>gfmd<replaceable>n</replaceable>_AUTH_TYPES</varname></term>
 <listitem>
 <para>
-認証タイプ ("sharedsecret", "sasl_auth", "sasl", "tls_sharedsecret",
- "tls_client_certificate", "kerberos_auth", "kerberos", "gsi_auth",
- または "gsi") を空白区切りの文字列で指定します。
-この変数が定義されていない場合は、gfmd1 上で
-<command moreinfo="none">config-gfarm -T</command> を実行したときの
+クライアントホストに共有鍵秘密ファイルをコピーするかどうかを制御するために使用します。
+<varname> gfmd1_CONFIG_GFARM_OPTIONS </varname> に "sharedsecret"ないし "tls_sharedsecret" があれば
+特に設定しなくても共有鍵秘密ファイルがコピーされます。
+どちらの設定もなければ、gfmd1 上で <command moreinfo="none"> config-gfarm -T </command> を実行したときの
 <varname>AUTH_TYPES</varname> の値が採用されます。
-(変数 <varname>gfmd1_CONFIG_GFARM_OPTIONS</varname> の値によって、この
-ときの <varname>AUTH_TYPES</varname> の値は変わるので、注意して下さい。)
 </para>
 </listitem>
 </varlistentry>
@@ -307,14 +304,11 @@ gfsd サーバー上で <command moreinfo="none">gfservice-agent</command> コ�
 <term><varname>gfsd<replaceable>n</replaceable>_AUTH_TYPES</varname></term>
 <listitem>
 <para>
-認証タイプ ("sharedsecret", "sasl_auth", "sasl", "tls_sharedsecret",
- "tls_client_certificate", "kerberos_auth", "kerberos", "gsi_auth",
- または "gsi") を空白区切りの文字列で指定します。
-この変数が定義されていない場合は、gfmd1 上で
-<command moreinfo="none">config-gfarm -T</command> を実行したときの
+クライアントホストに共有鍵秘密ファイルをコピーするかどうかを制御するために使用します。
+<varname> gfmd1_CONFIG_GFARM_OPTIONS </varname> に "sharedsecret"ないし "tls_sharedsecret" があれば
+特に設定しなくても共有鍵秘密ファイルがコピーされます。
+どちらの設定もなければ、gfmd1 上で <command moreinfo="none"> config-gfarm -T </command> を実行したときの
 <varname>AUTH_TYPES</varname> の値が採用されます。
-(変数 <varname>gfmd1_CONFIG_GFARM_OPTIONS</varname> の値によって、この
-ときの <varname>AUTH_TYPES</varname> の値は変わるので、注意して下さい。)
 </para>
 </listitem>
 </varlistentry>
@@ -464,14 +458,11 @@ gfarm2.confファイルのパスと同じパスを使用します(gfarm2.confフ
 <term><varname>client<replaceable>n</replaceable>_AUTH_TYPES</varname></term>
 <listitem>
 <para>
-認証タイプ ("sharedsecret", "sasl_auth", "sasl", "tls_sharedsecret",
- "tls_client_certificate", "kerberos_auth", "kerberos", "gsi_auth",
- または "gsi") を空白区切りの文字列で指定します。
-この変数が定義されていない場合は、gfmd1 上で
-<command moreinfo="none">config-gfarm -T</command> を実行したときの
+クライアントホストに共有鍵秘密ファイルをコピーするかどうかを制御するために使用します。
+<varname> gfmd1_CONFIG_GFARM_OPTIONS </varname> に "sharedsecret"ないし "tls_sharedsecret" があれば
+特に設定しなくても共有鍵秘密ファイルがコピーされます。
+どちらの設定もなければ、gfmd1 上で <command moreinfo="none"> config-gfarm -T </command> を実行したときの
 <varname>AUTH_TYPES</varname> の値が採用されます。
-(変数 <varname>gfmd1_CONFIG_GFARM_OPTIONS</varname> の値によって、この
-ときの <varname>AUTH_TYPES</varname> の値は変わるので、注意して下さい。)
 </para>
 </listitem>
 </varlistentry>

--- a/doc/docbook/ja/ref/man5/gfservice.conf.5.docbook
+++ b/doc/docbook/ja/ref/man5/gfservice.conf.5.docbook
@@ -5,7 +5,7 @@
 
 <refentry id="gfservice.conf.5">
 
-<refentryinfo><date>12 May 2026</date></refentryinfo>
+<refentryinfo><date>14 May 2026</date></refentryinfo>
 
 <refmeta>
 <refentrytitle>gfservice.conf</refentrytitle>
@@ -182,6 +182,9 @@ gfmd サーバー上で <command moreinfo="none">gfservice-agent</command> コ�
 <term><varname>gfmd<replaceable>n</replaceable>_AUTH_TYPES</varname></term>
 <listitem>
 <para>
+認証タイプ ("sharedsecret", "sasl_auth", "sasl", "tls_sharedsecret",
+"tls_client_certificate", "kerberos_auth", "kerberos", "gsi_auth",
+または "gsi") を空白区切りの文字列で指定します。
 この gfmd ホストに共有鍵秘密ファイルをコピーするかどうかを制御するために使用します。
 <varname> gfmd1_CONFIG_GFARM_OPTIONS </varname> に "sharedsecret"ないし "tls_sharedsecret" があれば
 特に設定しなくても共有鍵秘密ファイルがコピーされます。
@@ -304,6 +307,9 @@ gfsd サーバー上で <command moreinfo="none">gfservice-agent</command> コ�
 <term><varname>gfsd<replaceable>n</replaceable>_AUTH_TYPES</varname></term>
 <listitem>
 <para>
+認証タイプ ("sharedsecret", "sasl_auth", "sasl", "tls_sharedsecret",
+"tls_client_certificate", "kerberos_auth", "kerberos", "gsi_auth",
+または "gsi") を空白区切りの文字列で指定します。
 この gfsd ホストに共有鍵秘密ファイルをコピーするかどうかを制御するために使用します。
 <varname> gfmd1_CONFIG_GFARM_OPTIONS </varname> に "sharedsecret"ないし "tls_sharedsecret" があれば
 特に設定しなくても共有鍵秘密ファイルがコピーされます。
@@ -458,6 +464,9 @@ gfarm2.confファイルのパスと同じパスを使用します(gfarm2.confフ
 <term><varname>client<replaceable>n</replaceable>_AUTH_TYPES</varname></term>
 <listitem>
 <para>
+認証タイプ ("sharedsecret", "sasl_auth", "sasl", "tls_sharedsecret",
+"tls_client_certificate", "kerberos_auth", "kerberos", "gsi_auth",
+または "gsi") を空白区切りの文字列で指定します。
 このクライアントホストに共有鍵秘密ファイルをコピーするかどうかを制御するために使用します。
 <varname> gfmd1_CONFIG_GFARM_OPTIONS </varname> に "sharedsecret"ないし "tls_sharedsecret" があれば
 特に設定しなくても共有鍵秘密ファイルがコピーされます。

--- a/makes/var.mk
+++ b/makes/var.mk
@@ -99,6 +99,8 @@ private_dir = ./private
 
 .SUFFIXES: .a .la .ln .o .lo .s .S .c .cc .f .y .l .msg .cat
 
+.DELETE_ON_ERROR:
+
 .c.lo:
 	$(LTCOMPILE) -c $(srcdir)/$*.c
 


### PR DESCRIPTION
Enable .DELETE_ON_ERROR to avoid leaving incomplete generated files.

Also update gfservice.conf documentation about shared key distribution behavior.