### PR TITLE
docker/dist: support proxy environment

### DIFF
--- a/docker/dist/README.md
+++ b/docker/dist/README.md
@@ -11,6 +11,75 @@
    % git clone https://github.com/oss-tsukuba/gfarm.git
 ```
 
+## Proxy configuration (optional)
+
+If you are in a proxy environment, configure proxy-related
+environment variables before pulling Docker images or executing
+Docker-related commands such as `minica.sh`, `docker compose build`,
+or `docker compose up`.
+
+The following environment variables are required in a proxy environment.
+
+`PROXY_HOST` and `PROXY_PORT` are used for the `jwt-server`
+related Docker images, and in this case `jwt-server`,
+`jwt-server2`, and `keycloak` must be included in
+`no_proxy`/`NO_PROXY`.
+
+Example:
+
+    % export PROXY_HOST=proxy.example.com
+    % export PROXY_PORT=8080
+
+    % export http_proxy=http://${PROXY_HOST}:${PROXY_PORT}
+    % export https_proxy=http://${PROXY_HOST}:${PROXY_PORT}
+    % export HTTP_PROXY=http://${PROXY_HOST}:${PROXY_PORT}
+    % export HTTPS_PROXY=http://${PROXY_HOST}:${PROXY_PORT}
+
+    % export no_proxy=localhost,127.0.0.1,jwt-server,jwt-server2,keycloak
+    % export NO_PROXY=localhost,127.0.0.1,jwt-server,jwt-server2,keycloak
+
+If Docker daemon proxy configuration is required, create a systemd
+drop-in file.
+
+    % sudo mkdir -p /etc/systemd/system/docker.service.d
+
+    % sudo vi /etc/systemd/system/docker.service.d/http-proxy.conf
+
+Example:
+
+    [Service]
+    Environment="http_proxy=..."
+    Environment="https_proxy=..."
+    Environment="HTTP_PROXY=..."
+    Environment="HTTPS_PROXY=..."
+    Environment="no_proxy=localhost,127.0.0.1,jwt-server,jwt-server2,keycloak"
+    Environment="NO_PROXY=localhost,127.0.0.1,jwt-server,jwt-server2,keycloak"
+
+Reload systemd configuration and restart Docker.
+
+    % sudo systemctl daemon-reload
+    % sudo systemctl restart docker
+
+If Docker client proxy configuration is required, create
+`~/.docker/config.json`.
+
+    % mkdir -p ~/.docker
+
+    % vi ~/.docker/config.json
+
+Example:
+
+    {
+      "proxies": {
+        "default": {
+          "httpProxy": "...",
+          "httpsProxy": "...",
+          "noProxy": "localhost,127.0.0.1,jwt-server,jwt-server2,keycloak"
+        }
+      }
+    }
+
+
 ## Explore on virtual clusters by VS Code dev containers
 
 This section is an option only for VS Code users.
@@ -66,7 +135,7 @@ When you install Gfarm by `all.sh`, `regress.sh` and `failover.sh` are available
     % cd ..
 
 - connect remote desktop to localhost:13389
-- login user/user
+- login ubuntu/ubuntu
 - launch Firefox (or Chromium (/rdesktop/chromium-start.sh))
 - open a terminal
 - execute `/rdesktop/install-ca-for-browser.sh`

--- a/docker/dist/jwt-server/docker-compose.yaml
+++ b/docker/dist/jwt-server/docker-compose.yaml
@@ -43,7 +43,14 @@ services:
     networks:
       gfarm_net:
   jwt-server:
-    build: jwt-server
+    build:
+      context: jwt-server
+      args:
+        MAVEN_OPTS: >-
+          -Dhttp.proxyHost=${PROXY_HOST:-}
+          -Dhttp.proxyPort=${PROXY_PORT:-}
+          -Dhttps.proxyHost=${PROXY_HOST:-}
+          -Dhttps.proxyPort=${PROXY_PORT:-}
     hostname: jwt-server
     container_name: gfarm-jwt-server
     volumes:
@@ -55,7 +62,14 @@ services:
       - gfarm_net
     privileged: true
   jwt-server2:
-    build: jwt-server
+    build:
+      context: jwt-server
+      args:
+        MAVEN_OPTS: >-
+          -Dhttp.proxyHost=${PROXY_HOST:-}
+          -Dhttp.proxyPort=${PROXY_PORT:-}
+          -Dhttps.proxyHost=${PROXY_HOST:-}
+          -Dhttps.proxyPort=${PROXY_PORT:-}
     hostname: jwt-server2
     container_name: gfarm-jwt-server2
     volumes:

--- a/docker/dist/jwt-server/jwt-server/Dockerfile
+++ b/docker/dist/jwt-server/jwt-server/Dockerfile
@@ -1,5 +1,7 @@
 FROM rockylinux/rockylinux:9
 
+ARG MAVEN_OPTS
+
 RUN dnf -y update \
  && dnf -y install \
     git java-21-openjdk-devel httpd mod_ssl maven mariadb-server wget


### PR DESCRIPTION
Pass proxy-related Maven options to jwt-server builds and document required proxy configuration for Docker environments.

Also update the rdesktop login example in README.md.