### PR TITLE
docker/dev: support no_proxy in XOAUTH2 configuration

### DIFF
--- a/docker/dev/README.en
+++ b/docker/dev/README.en
@@ -37,6 +37,31 @@ Restriction
   $ sudo update-grub
   $ sudo reboot
 
+# Proxy configuration (optional)
+
+  If you are in a proxy environment, configure the proxy settings in
+  "docker/dev/config.mk".
+
+  In some environments, Docker daemon proxy configuration may also be
+  required. Create a systemd drop-in file such as:
+
+  /etc/systemd/system/docker.service.d/http-proxy.conf
+
+  Example:
+
+  [Service]
+  Environment="http_proxy=http://proxy.example.com:8080"
+  Environment="https_proxy=http://proxy.example.com:8080"
+  Environment="HTTP_PROXY=http://proxy.example.com:8080"
+  Environment="HTTPS_PROXY=http://proxy.example.com:8080"
+  Environment="no_proxy=localhost,127.0.0.1,jwt-server,keycloak"
+  Environment="NO_PROXY=localhost,127.0.0.1,jwt-server,keycloak"
+
+  After updating the configuration:
+
+  $ sudo systemctl daemon-reload
+  $ sudo systemctl restart docker
+
 Quick start
 ===========
 

--- a/docker/dev/common/base.mk
+++ b/docker/dev/common/base.mk
@@ -83,7 +83,7 @@ DOCKER_BUILD_FLAGS += \
 		--build-arg GFDOCKER_PROXY_HOST='$(GFDOCKER_PROXY_HOST)' \
 		--build-arg GFDOCKER_PROXY_PORT='$(GFDOCKER_PROXY_PORT)' \
 		--build-arg GFDOCKER_ENABLE_PROXY='$(GFDOCKER_ENABLE_PROXY)' \
-                --build-arg MAVEN_OPTS='-Dhttp.proxyHost=$(GFDOCKER_PROXY_HOST) \
+		--build-arg MAVEN_OPTS='-Dhttp.proxyHost=$(GFDOCKER_PROXY_HOST) \
                         -Dhttp.proxyPort=$(GFDOCKER_PROXY_PORT) \
                         -Dhttps.proxyHost=$(GFDOCKER_PROXY_HOST) \
                         -Dhttps.proxyPort=$(GFDOCKER_PROXY_PORT)'

--- a/docker/dev/common/oauth2/tomcat/Dockerfile
+++ b/docker/dev/common/oauth2/tomcat/Dockerfile
@@ -1,4 +1,12 @@
-FROM jelastic/maven:3.9.5-openjdk-21 as BUILD
+# NOTE:
+# In proxy environments, build failures have been observed depending on
+# the Maven and JDK versions used in the build image.
+
+# Observations:
+# - Maven 3.9.x may fail to build.
+# - OpenJDK 17 may fail even with Maven versions earlier than 3.9.
+# - Maven 3.8.7 with OpenJDK 21 has shown stable behavior.
+FROM jelastic/maven:3.8.7-openjdk-21.ea-b7 AS build
 WORKDIR /build
 COPY jwt-server/pom.xml /build
 COPY jwt-server/src /build/src

--- a/docker/dev/common/up.rc
+++ b/docker/dev/common/up.rc
@@ -24,6 +24,7 @@ set -eux -o pipefail
 
 # the followings are optional:
 #: $https_proxy
+#: $no_proxy
 #: $GFDOCKER_ENABLE_PROXY
 
 gfarm_src_path="/work/gfarm"
@@ -198,6 +199,11 @@ _EOF_
 	cat <<_EOF_
 proxy: ${https_proxy}
 _EOF_
+        if [ -n "${no_proxy:-}" ]; then
+    cat <<_EOF_
+no_proxy: ${no_proxy}
+_EOF_
+        fi
       fi
     ) >/tmp/sasl_gfarm-client.conf
     (
@@ -214,6 +220,12 @@ _EOF_
 	cat <<_EOF_
 proxy: ${https_proxy}
 _EOF_
+
+        if [ -n "${no_proxy:-}" ]; then
+    cat <<_EOF_
+no_proxy: ${no_proxy}
+_EOF_
+        fi
       fi
     ) >/tmp/sasl_gfarm.conf
   fi

--- a/docker/dev/config-default.mk
+++ b/docker/dev/config-default.mk
@@ -18,7 +18,7 @@ DOCKER_COMPOSE_CMD = docker compose
 #GFDOCKER_PROXY_PORT = 8080
 GFDOCKER_PROXY_HOST =
 GFDOCKER_PROXY_PORT =
-GFDOCKER_NO_PROXY = localhost,127.0.0.1
+GFDOCKER_NO_PROXY = localhost,127.0.0.1,jwt-server,keycloak
 GFDOCKER_NUM_JOBS = 8
 
 # number of containers


### PR DESCRIPTION
Pass no_proxy settings to generated SASL XOAUTH2 configuration files when proxy support is enabled.

Also add proxy configuration documentation for docker/dev and update the jwt-server build image.

In proxy environments, Maven package failures were observed with some Maven/OpenJDK combinations. Use Maven 3.8.7 with OpenJDK 21, which has shown stable behavior when building jwt-server related components.