### PR TITLE
docker/dev: fix JWT server build in proxy environments

### DIFF
--- a/docker/dev/common/base.mk
+++ b/docker/dev/common/base.mk
@@ -82,11 +82,7 @@ DOCKER_BUILD_FLAGS += \
 		--build-arg NO_PROXY='$(GFDOCKER_NO_PROXY)' \
 		--build-arg GFDOCKER_PROXY_HOST='$(GFDOCKER_PROXY_HOST)' \
 		--build-arg GFDOCKER_PROXY_PORT='$(GFDOCKER_PROXY_PORT)' \
-		--build-arg GFDOCKER_ENABLE_PROXY='$(GFDOCKER_ENABLE_PROXY)' \
-		--build-arg MAVEN_OPTS='-Dhttp.proxyHost=$(GFDOCKER_PROXY_HOST) \
-                        -Dhttp.proxyPort=$(GFDOCKER_PROXY_PORT) \
-                        -Dhttps.proxyHost=$(GFDOCKER_PROXY_HOST) \
-                        -Dhttps.proxyPort=$(GFDOCKER_PROXY_PORT)'
+		--build-arg GFDOCKER_ENABLE_PROXY='$(GFDOCKER_ENABLE_PROXY)'
 endif
 
 IMAGE_BASENAME = gfarm-dev

--- a/docker/dev/common/oauth2/tomcat/Dockerfile
+++ b/docker/dev/common/oauth2/tomcat/Dockerfile
@@ -1,17 +1,40 @@
 # NOTE:
-# In proxy environments, build failures have been observed depending on
-# the Maven and JDK versions used in the build image.
-
+# When using MAVEN_OPTS for proxy configuration, build failures have been
+# observed depending on the Maven and JDK versions used in the build image.
+#
 # Observations:
-# - Maven 3.9.x may fail to build.
+# - Maven 3.9.5 + OpenJDK 21: build failed in proxy environments.
+# - Maven 3.9.16 + OpenJDK 21: build failed in proxy environments.
 # - OpenJDK 17 may fail even with Maven versions earlier than 3.9.
-# - Maven 3.8.7 with OpenJDK 21 has shown stable behavior.
-FROM jelastic/maven:3.8.7-openjdk-21.ea-b7 AS build
+# - Maven 3.8.7 + OpenJDK 21 has shown stable behavior.
+#
+# Proxy configuration is now provided via Maven settings.xml instead of
+# MAVEN_OPTS.
+FROM maven:3.9.16-eclipse-temurin-21 AS build
 WORKDIR /build
 COPY jwt-server/pom.xml /build
 COPY jwt-server/src /build/src
 COPY docker/dev/common/oauth2/tomcat/application.properties /build/src/main/resources
-ARG MAVEN_OPTS
+
+ARG GFDOCKER_PROXY_HOST
+ARG GFDOCKER_PROXY_PORT
+ARG GFDOCKER_ENABLE_PROXY
+ARG no_proxy
+
+ENV GFDOCKER_PROXY_HOST=${GFDOCKER_PROXY_HOST}
+ENV GFDOCKER_PROXY_PORT=${GFDOCKER_PROXY_PORT}
+ENV no_proxy=${no_proxy}
+
+RUN mkdir -p /root/.m2
+
+COPY docker/dev/common/oauth2/tomcat/settings-proxy.xml \
+    /root/.m2/settings-proxy.xml
+
+RUN if [ "$GFDOCKER_ENABLE_PROXY" = "true" ]; then \
+        cp /root/.m2/settings-proxy.xml \
+           /root/.m2/settings.xml; \
+    fi
+
 RUN mvn package
 
 FROM tomcat:10.1.30-jdk21

--- a/docker/dev/common/oauth2/tomcat/settings-proxy.xml
+++ b/docker/dev/common/oauth2/tomcat/settings-proxy.xml
@@ -1,0 +1,21 @@
+<settings>
+  <proxies>
+    <proxy>
+      <id>http-proxy</id>
+      <active>true</active>
+      <protocol>http</protocol>
+      <host>${env.GFDOCKER_PROXY_HOST}</host>
+      <port>${env.GFDOCKER_PROXY_PORT}</port>
+      <nonProxyHosts>${env.no_proxy}</nonProxyHosts>
+    </proxy>
+
+    <proxy>
+      <id>https-proxy</id>
+      <active>true</active>
+      <protocol>https</protocol>
+      <host>${env.GFDOCKER_PROXY_HOST}</host>
+      <port>${env.GFDOCKER_PROXY_PORT}</port>
+      <nonProxyHosts>${env.no_proxy}</nonProxyHosts>
+    </proxy>
+  </proxies>
+</settings>


### PR DESCRIPTION
Use Maven settings.xml instead of MAVEN_OPTS for proxy configuration when building the OAuth2 JWT server.