### PR TITLE
docker/dev: fix authconfig and ANONYMOUS regress issues

### DIFF
--- a/docker/dev/common/authconfig
+++ b/docker/dev/common/authconfig
@@ -157,6 +157,50 @@ gen_auth_config()
 	) >>"${auth_config_dir}/${config_name}.conf"
 }
 
+gen_auth_trial_order_config()
+{
+	config_name=$1
+	shift
+	(
+		order=""
+		while [ $# -gt 0 ]
+		do
+			a=$1
+			shift
+			[ -z "$a" ] && continue
+			case "$a" in
+			all)
+				order=" sharedsecret sasl_auth sasl tls_sharedsecret \
+tls_client_certificate kerberos_auth kerberos gsi_auth gsi"
+				break
+				;;
+			sasl.*)
+				a=sasl
+				;;
+			sasl_auth.*)
+				a=sasl_auth
+				;;
+			esac
+			case " $order " in
+			*" $a "*)
+				;;
+			*)
+				order="$order $a"
+				;;
+			esac
+		done
+		echo "auth_trial_order${order}"
+	) >> "${auth_config_dir}/${config_name}.conf"
+}
+
+gen_auth_finish()
+{
+	config_name=$1
+	(
+		echo "auth disable * *"
+	) >> "${auth_config_dir}/${config_name}.conf"
+}
+
 gen_auth_sasl_config()
 {
 	auth_method=$1
@@ -409,7 +453,10 @@ fi
 clear_auth_config auth-gfmd
 if [ "${gfmd_gfmd}" != "${gfsd_gfmd}" ]; then
 	gen_auth_config auth-gfmd gfmd "${gfmd_gfmd}"
+	gen_auth_config auth-gfmd gfmd "${client_gfmd}"
 	gen_auth_config auth-gfmd gfsd "${gfsd_gfmd}"
+	gen_auth_config auth-gfmd gfsd "${client_gfmd}"
+	gen_auth_trial_order_config auth-gfmd "${gfmd_gfmd}"
 	gen_auth_config auth-gfmd client "all"
 elif [ "${gfmd_gfmd}" = "all" \
     -o "${gfmd_gfmd}" = "sharedsecret" ]; then
@@ -418,7 +465,10 @@ elif [ "${gfmd_gfmd}" = "${client_gfmd}" ]; then
 	gen_auth_config auth-gfmd "all" "${gfmd_gfmd}"
 else
 	gen_auth_config auth-gfmd gfmd "${gfmd_gfmd}"
+	gen_auth_config auth-gfmd gfmd "${client_gfmd}"
 	gen_auth_config auth-gfmd gfsd "${gfsd_gfmd}"
+	gen_auth_config auth-gfmd gfsd "${client_gfmd}"
+	gen_auth_trial_order_config auth-gfmd "${gfmd_gfmd}"
 	# use "all" instead of "${client_gfmd}", make it client-controllable
 	gen_auth_config auth-gfmd client "all"
 fi
@@ -429,7 +479,10 @@ fi
 clear_auth_config auth-gfsd
 if [ "${gfsd_gfsd}" != "${gfsd_gfmd}" ]; then
 	gen_auth_config auth-gfsd gfmd "${gfsd_gfmd}"
+	gen_auth_config auth-gfsd gfmd "${client_gfsd}"
 	gen_auth_config auth-gfsd gfsd "${gfsd_gfsd}"
+	gen_auth_config auth-gfsd gfsd "${client_gfsd}"
+	gen_auth_trial_order_config auth-gfsd "${gfsd_gfmd}" "${gfsd_gfsd}"
 	gen_auth_config auth-gfsd client "all"
 elif [ "${gfsd_gfsd}" = "all" \
     -o "${gfsd_gfsd}" = "sharedsecret" ]; then
@@ -438,7 +491,10 @@ elif [ "${gfsd_gfsd}" = "${client_gfmd}" ]; then
 	gen_auth_config auth-gfsd "all" "${gfsd_gfsd}"
 else
 	gen_auth_config auth-gfsd gfmd "${gfsd_gfmd}"
+	gen_auth_config auth-gfsd gfmd "${client_gfsd}"
 	gen_auth_config auth-gfsd gfsd "${gfsd_gfsd}"
+	gen_auth_config auth-gfsd gfsd "${client_gfsd}"
+	gen_auth_trial_order_config auth-gfsd "${gfsd_gfsd}"
 	# use "all" instead of "${client_gfsd}", make it client-controllable
 	gen_auth_config auth-gfsd client "all"
 fi
@@ -450,12 +506,14 @@ clear_auth_config auth-client
 clear_auth_config auth-client.sasl
 if [ "${client_gfsd}" = "${client_gfmd}" ]; then
 	gen_auth_config auth-client "all" "${client_gfsd}"
+	gen_auth_trial_order_config auth-client "${client_gfsd}"
 	case ${client_gfsd} in
 	sasl*)	gen_auth_sasl_config "${client_gfsd}";;
 	esac
 else
 	gen_auth_config auth-client gfmd "${client_gfmd}"
 	gen_auth_config auth-client gfsd "${client_gfsd}"
+	gen_auth_trial_order_config auth-client "${client_gfmd}" "${client_gfsd}"
 	case "${client_gfmd}/${client_gfsd}" in
 	sasl*/sasl*)
 		gfmd_sasl_mech=$(echo "client_gfmd" | sed 's/sasl[_a-z]*//')
@@ -480,6 +538,10 @@ if ! ${gfsd_needs_host_cred}; then
 	# both gfsd and clients, but that's OK in this case.
 	gen_cred_config auth-client
 fi
+
+gen_auth_finish auth-gfmd
+gen_auth_finish auth-gfsd
+gen_auth_finish auth-client
 
 if "${no_restart}"; then
 	:

--- a/docker/dev/common/regress.rc
+++ b/docker/dev/common/regress.rc
@@ -61,34 +61,53 @@ $RUN_REGRESS $GFARM_SRCDIR $LOG_REMOTE_NONROOT false \
 ssh $gfsdhost $RUN_REGRESS $GFARM_SRCDIR $LOG_LOCAL_ROOT true \
 	$GFARM_TEST_CKSUM_MISMATCH $parallel || true
 
-# remote access and non-gfarmroot in tenant 2
-sudo su - "${GFDOCKER_TENANT_ADMIN_USER}" \
-    $RUN_REGRESS_TENANT $GFARM_SRCDIR_TENANT $LOG_REMOTE_NONROOT_TENANT false \
-	$GFARM_TEST_CKSUM_MISMATCH $parallel || true
+# Run the tests in tenant 2.
+# Skip when running as anonymous because anonymous already belongs to
+# tenant2 and would execute the same test cases twice.
+if [ "anonymous" != "$(gfwhoami)" ]; then
+	# remote access and non-gfarmroot in tenant 2
+	sudo su - "${GFDOCKER_TENANT_ADMIN_USER}" \
+		$RUN_REGRESS_TENANT $GFARM_SRCDIR_TENANT $LOG_REMOTE_NONROOT_TENANT false \
+		$GFARM_TEST_CKSUM_MISMATCH $parallel || true
 
-# local access and gfarmroot in tenant 2
-sudo su - "${GFDOCKER_TENANT_ADMIN_USER}" -c "ssh $gfsdhost \
-    $RUN_REGRESS_TENANT $GFARM_SRCDIR_TENANT $LOG_LOCAL_ROOT_TENANT true \
-	$GFARM_TEST_CKSUM_MISMATCH $parallel" || true
+	# local access and gfarmroot in tenant 2
+	sudo su - "${GFDOCKER_TENANT_ADMIN_USER}" -c "ssh $gfsdhost \
+		$RUN_REGRESS_TENANT $GFARM_SRCDIR_TENANT $LOG_LOCAL_ROOT_TENANT true \
+		$GFARM_TEST_CKSUM_MISMATCH $parallel" || true
 
-scp $gfsdhost:$GFARM_SRCDIR/regress/$LOG_LOCAL_ROOT .
-sudo su - "${GFDOCKER_TENANT_ADMIN_USER}" \
-  -c "cat $GFARM_SRCDIR_TENANT/regress/$LOG_REMOTE_NONROOT_TENANT" \
-  >$LOG_REMOTE_NONROOT_TENANT
-sudo su - "${GFDOCKER_TENANT_ADMIN_USER}" \
-  -c "ssh $gfsdhost cat $GFARM_SRCDIR_TENANT/regress/$LOG_LOCAL_ROOT_TENANT" \
-  >$LOG_LOCAL_ROOT_TENANT
-./addup.sh -v $LOG_REMOTE_NONROOT $LOG_LOCAL_ROOT \
-	$LOG_REMOTE_NONROOT_TENANT $LOG_LOCAL_ROOT_TENANT
-./addup.sh $LOG_REMOTE_NONROOT $LOG_LOCAL_ROOT \
-	$LOG_REMOTE_NONROOT_TENANT $LOG_LOCAL_ROOT_TENANT
-res=$?
+	scp $gfsdhost:$GFARM_SRCDIR/regress/$LOG_LOCAL_ROOT .
+	sudo su - "${GFDOCKER_TENANT_ADMIN_USER}" \
+	-c "cat $GFARM_SRCDIR_TENANT/regress/$LOG_REMOTE_NONROOT_TENANT" \
+	>$LOG_REMOTE_NONROOT_TENANT
+	sudo su - "${GFDOCKER_TENANT_ADMIN_USER}" \
+	-c "ssh $gfsdhost cat $GFARM_SRCDIR_TENANT/regress/$LOG_LOCAL_ROOT_TENANT" \
+	>$LOG_LOCAL_ROOT_TENANT
+
+	./addup.sh -v $LOG_REMOTE_NONROOT $LOG_LOCAL_ROOT \
+		$LOG_REMOTE_NONROOT_TENANT $LOG_LOCAL_ROOT_TENANT
+	./addup.sh $LOG_REMOTE_NONROOT $LOG_LOCAL_ROOT \
+		$LOG_REMOTE_NONROOT_TENANT $LOG_LOCAL_ROOT_TENANT
+	res=$?
+
+	cp $LOG_REMOTE_NONROOT_TENANT \
+	${LOG_DIR}/${LOG_PREFIX}.${LOG_REMOTE_NONROOT_TENANT}
+	cp $LOG_LOCAL_ROOT_TENANT \
+		${LOG_DIR}/${LOG_PREFIX}.${LOG_LOCAL_ROOT_TENANT}
+else
+	scp $gfsdhost:$GFARM_SRCDIR/regress/$LOG_LOCAL_ROOT .
+	sudo su - "${GFDOCKER_TENANT_ADMIN_USER}" \
+	-c "cat $GFARM_SRCDIR_TENANT/regress/$LOG_REMOTE_NONROOT_TENANT" \
+	>$LOG_REMOTE_NONROOT_TENANT
+	sudo su - "${GFDOCKER_TENANT_ADMIN_USER}" \
+	-c "ssh $gfsdhost cat $GFARM_SRCDIR_TENANT/regress/$LOG_LOCAL_ROOT_TENANT" \
+	>$LOG_LOCAL_ROOT_TENANT
+
+	./addup.sh -v $LOG_REMOTE_NONROOT $LOG_LOCAL_ROOT
+	./addup.sh $LOG_REMOTE_NONROOT $LOG_LOCAL_ROOT
+	res=$?
+fi
 
 cp $LOG_REMOTE_NONROOT ${LOG_DIR}/${LOG_PREFIX}.${LOG_REMOTE_NONROOT}
 cp $LOG_LOCAL_ROOT ${LOG_DIR}/${LOG_PREFIX}.${LOG_LOCAL_ROOT}
-cp $LOG_REMOTE_NONROOT_TENANT \
-	${LOG_DIR}/${LOG_PREFIX}.${LOG_REMOTE_NONROOT_TENANT}
-cp $LOG_LOCAL_ROOT_TENANT \
-	${LOG_DIR}/${LOG_PREFIX}.${LOG_LOCAL_ROOT_TENANT}
 
 exit $res

--- a/docker/dev/common/regress.rc
+++ b/docker/dev/common/regress.rc
@@ -61,10 +61,17 @@ $RUN_REGRESS $GFARM_SRCDIR $LOG_REMOTE_NONROOT false \
 ssh $gfsdhost $RUN_REGRESS $GFARM_SRCDIR $LOG_LOCAL_ROOT true \
 	$GFARM_TEST_CKSUM_MISMATCH $parallel || true
 
-# Run the tests in tenant 2.
-# Skip when running as anonymous because anonymous already belongs to
-# tenant2 and would execute the same test cases twice.
-if [ "anonymous" != "$(gfwhoami)" ]; then
+scp $gfsdhost:$GFARM_SRCDIR/regress/$LOG_LOCAL_ROOT .
+
+if [ "anonymous" = "$(gfwhoami)" ]; then
+	./addup.sh -v $LOG_REMOTE_NONROOT $LOG_LOCAL_ROOT
+	./addup.sh $LOG_REMOTE_NONROOT $LOG_LOCAL_ROOT
+	res=$?
+else
+	# Do this only when running as non-anonymous
+	# because anonymous already belongs to tenant2
+	# and would execute the same test cases twice.
+
 	# remote access and non-gfarmroot in tenant 2
 	sudo su - "${GFDOCKER_TENANT_ADMIN_USER}" \
 		$RUN_REGRESS_TENANT $GFARM_SRCDIR_TENANT $LOG_REMOTE_NONROOT_TENANT false \
@@ -75,13 +82,12 @@ if [ "anonymous" != "$(gfwhoami)" ]; then
 		$RUN_REGRESS_TENANT $GFARM_SRCDIR_TENANT $LOG_LOCAL_ROOT_TENANT true \
 		$GFARM_TEST_CKSUM_MISMATCH $parallel" || true
 
-	scp $gfsdhost:$GFARM_SRCDIR/regress/$LOG_LOCAL_ROOT .
 	sudo su - "${GFDOCKER_TENANT_ADMIN_USER}" \
-	-c "cat $GFARM_SRCDIR_TENANT/regress/$LOG_REMOTE_NONROOT_TENANT" \
-	>$LOG_REMOTE_NONROOT_TENANT
+		-c "cat $GFARM_SRCDIR_TENANT/regress/$LOG_REMOTE_NONROOT_TENANT" \
+		>$LOG_REMOTE_NONROOT_TENANT
 	sudo su - "${GFDOCKER_TENANT_ADMIN_USER}" \
-	-c "ssh $gfsdhost cat $GFARM_SRCDIR_TENANT/regress/$LOG_LOCAL_ROOT_TENANT" \
-	>$LOG_LOCAL_ROOT_TENANT
+		-c "ssh $gfsdhost cat $GFARM_SRCDIR_TENANT/regress/$LOG_LOCAL_ROOT_TENANT" \
+		>$LOG_LOCAL_ROOT_TENANT
 
 	./addup.sh -v $LOG_REMOTE_NONROOT $LOG_LOCAL_ROOT \
 		$LOG_REMOTE_NONROOT_TENANT $LOG_LOCAL_ROOT_TENANT
@@ -90,21 +96,9 @@ if [ "anonymous" != "$(gfwhoami)" ]; then
 	res=$?
 
 	cp $LOG_REMOTE_NONROOT_TENANT \
-	${LOG_DIR}/${LOG_PREFIX}.${LOG_REMOTE_NONROOT_TENANT}
+		${LOG_DIR}/${LOG_PREFIX}.${LOG_REMOTE_NONROOT_TENANT}
 	cp $LOG_LOCAL_ROOT_TENANT \
 		${LOG_DIR}/${LOG_PREFIX}.${LOG_LOCAL_ROOT_TENANT}
-else
-	scp $gfsdhost:$GFARM_SRCDIR/regress/$LOG_LOCAL_ROOT .
-	sudo su - "${GFDOCKER_TENANT_ADMIN_USER}" \
-	-c "cat $GFARM_SRCDIR_TENANT/regress/$LOG_REMOTE_NONROOT_TENANT" \
-	>$LOG_REMOTE_NONROOT_TENANT
-	sudo su - "${GFDOCKER_TENANT_ADMIN_USER}" \
-	-c "ssh $gfsdhost cat $GFARM_SRCDIR_TENANT/regress/$LOG_LOCAL_ROOT_TENANT" \
-	>$LOG_LOCAL_ROOT_TENANT
-
-	./addup.sh -v $LOG_REMOTE_NONROOT $LOG_LOCAL_ROOT
-	./addup.sh $LOG_REMOTE_NONROOT $LOG_LOCAL_ROOT
-	res=$?
 fi
 
 cp $LOG_REMOTE_NONROOT ${LOG_DIR}/${LOG_PREFIX}.${LOG_REMOTE_NONROOT}

--- a/regress/gftool/gfusage/gfusage-common.sh
+++ b/regress/gftool/gfusage/gfusage-common.sh
@@ -10,7 +10,7 @@ DISABLE="disable"
 
 cleanup() {
     gfrm -rf $gftmp
-    if [ ${REPCHECK_STATUS} = ${ENABLE} ]; then
+    if [ "${REPCHECK_STATUS}" = ${ENABLE} ]; then
         gfrepcheck ${ENABLE}
     fi
 }
@@ -25,10 +25,10 @@ error() {
 
 setup() {
     # "gfrepcheck disable" is required
-    $regress/bin/am_I_gfarm_super_adm || exit $exit_unsupported
+    $regress/bin/am_I_gfarmadm || exit $exit_unsupported
 
     REPCHECK_STATUS=`gfrepcheck status | cut -d ' ' -f 1` || exit $exit_fail
-    if [ ${REPCHECK_STATUS} = ${ENABLE} ]; then
+    if [ "${REPCHECK_STATUS}" = ${ENABLE} ]; then
         gfrepcheck ${DISABLE}
     fi
     gfmkdir $gftmp || error "gfmkdir"

--- a/regress/manual/server/gfsd/spool_check/lost_found.sh
+++ b/regress/manual/server/gfsd/spool_check/lost_found.sh
@@ -181,7 +181,14 @@ check_lost_found() {
         if [ $EXIST -eq 1 ]; then
             echo >&2 "TEST_${TEST_NUM} NG: file was not moved in lost+found"
             clean_all
-            exit_code=$exit_fail
+            if [ "anonymous" == "$(gfwhoami)" ] &&
+               ! $regress/bin/am_I_in_default_tenant
+            then
+                #for docker/dev
+                exit_code=$exit_xfail
+            else
+                exit_code=$exit_fail
+            fi
         else
             echo "TEST_${TEST_NUM} OK: file was moved in lost+found"
         fi
@@ -189,7 +196,14 @@ check_lost_found() {
         if [ $EXIST -eq 0 ]; then
             echo >&2 "TEST_${TEST_NUM} NG: file exists in lost+found"
             clean_all
-            exit_code=$exit_fail
+            if [ "anonymous" == "$(gfwhoami)" ] &&
+               ! $regress/bin/am_I_in_default_tenant
+            then
+                #for docker/dev
+                exit_code=$exit_xfail
+            else
+                exit_code=$exit_fail
+            fi
         else
             echo "TEST_${TEST_NUM} OK: file does not exist in lost+found"
         fi


### PR DESCRIPTION
Fix authconfig so that authentication methods are configured consistently across client, gfsd, and gfmd hosts.

Previously, gfsd could remain configured with sharedsecret regardless of the requested authentication method, resulting in inconsistent regress test environments.

Also update ANONYMOUS regress execution:

- skip duplicate tenant2 regress runs for ANONYMOUS
- mark lost_found.sh as XFAIL in tenant2 environments where lost+found is not visible