### PR TITLE
docker/dist: support proxy settings in XOAUTH2 configuration

### DIFF
--- a/docker/dev/common/up.rc
+++ b/docker/dev/common/up.rc
@@ -195,16 +195,6 @@ if pkg-config --exists libsasl2; then
       cat <<_EOF_
 xoauth2_user_claim: ${GFDOCKER_SASL_XOAUTH2_USER_CLAIM}
 _EOF_
-      if "${GFDOCKER_ENABLE_PROXY:-false}"; then
-	cat <<_EOF_
-proxy: ${https_proxy}
-_EOF_
-        if [ -n "${no_proxy:-}" ]; then
-    cat <<_EOF_
-no_proxy: ${no_proxy}
-_EOF_
-        fi
-      fi
     ) >/tmp/sasl_gfarm-client.conf
     (
       cat <<_EOF_

--- a/docker/dist/all.sh
+++ b/docker/dist/all.sh
@@ -117,11 +117,6 @@ else
 	 sh $DISTDIR/install.sh $install_option)
 fi
 
-proxy_conf() {
-    [ -n "${https_proxy:-}" ] && echo "proxy: ${https_proxy}"
-    [ -n "${no_proxy:-}" ] && echo "no_proxy: ${no_proxy}"
-}
-
 {
 cat <<EOF
 log_level: 7
@@ -130,14 +125,14 @@ xoauth2_scope: hpci
 xoauth2_aud: hpci
 xoauth2_user_claim: hpci.id
 EOF
-proxy_conf
+[ -n "${https_proxy:-}" ] && echo "proxy: ${https_proxy}"
+[ -n "${no_proxy:-}" ] && echo "no_proxy: ${no_proxy}"
 } | sudo tee "$sasl_libdir/sasl2/gfarm.conf" >/dev/null
 
 {
 cat <<EOF
 xoauth2_user_claim: hpci.id
 EOF
-proxy_conf
 } | sudo tee "$sasl_libdir/sasl2/gfarm-client.conf" >/dev/null
 
 cp $sasl_libdir/sasl2/gfarm*.conf ~/local

--- a/docker/dist/all.sh
+++ b/docker/dist/all.sh
@@ -117,16 +117,28 @@ else
 	 sh $DISTDIR/install.sh $install_option)
 fi
 
-cat <<EOF | sudo tee $sasl_libdir/sasl2/gfarm.conf > /dev/null
+proxy_conf() {
+    [ -n "${https_proxy:-}" ] && echo "proxy: ${https_proxy}"
+    [ -n "${no_proxy:-}" ] && echo "no_proxy: ${no_proxy}"
+}
+
+{
+cat <<EOF
 log_level: 7
 mech_list: XOAUTH2 ANONYMOUS PLAIN
 xoauth2_scope: hpci
 xoauth2_aud: hpci
 xoauth2_user_claim: hpci.id
 EOF
-cat <<EOF | sudo tee $sasl_libdir/sasl2/gfarm-client.conf > /dev/null
+proxy_conf
+} | sudo tee "$sasl_libdir/sasl2/gfarm.conf" >/dev/null
+
+{
+cat <<EOF
 xoauth2_user_claim: hpci.id
 EOF
+proxy_conf
+} | sudo tee "$sasl_libdir/sasl2/gfarm-client.conf" >/dev/null
 
 cp $sasl_libdir/sasl2/gfarm*.conf ~/local
 gfarm-prun -p sudo cp local/gfarm*.conf $sasl_libdir/sasl2


### PR DESCRIPTION
Configure XOAUTH2 SASL plugin settings from container environment variables in docker/dist/all.sh.

- generate proxy configuration from https_proxy
- generate no_proxy configuration from no_proxy
- apply proxy settings to the SASL plugin configuration files gfarm.conf and gfarm-client.conf