### PR TITLE
docker/dev: fix jwt-agent build and CA setup

### DIFF
--- a/docker/dev/common/make-install-univ.sh
+++ b/docker/dev/common/make-install-univ.sh
@@ -68,11 +68,7 @@ if [ -d "/home/${GFDOCKER_PRIMARY_USER}/jwt-logon" ]; then
   make PREFIX=/usr/local install || exit 1
 fi
 
-# if proxy is set, the following fails for some unknown reason,
-# the error is:
-#	go: golang.org/x/crypto@v0.0.0-20220722155217-630584e8d5aa: Get "https://proxy.golang.org/golang.org/x/crypto/@v/v0.0.0-20220722155217-630584e8d5aa.info": dial tcp: lookup proxy.golang.org on 8.8.4.4:53: read udp 172.17.0.2:40024->8.8.4.4:53: i/o timeout
-if  [ -d "/home/${GFDOCKER_PRIMARY_USER}/jwt-agent" ] && type go 2>/dev/null &&
-    ! "${GFDOCKER_ENABLE_PROXY}"
+if  [ -d "/home/${GFDOCKER_PRIMARY_USER}/jwt-agent" ] && type go 2>/dev/null
 then
   su - "$GFDOCKER_PRIMARY_USER" -c "cd ~/jwt-agent && make" &&
     cd "/home/${GFDOCKER_PRIMARY_USER}/jwt-agent" &&

--- a/docker/dev/common/up.rc
+++ b/docker/dev/common/up.rc
@@ -571,22 +571,47 @@ CA_DIR=/root/simple_ca
 ### update CA for OAuth-related web servers
 
 case $GFDOCKER_PRJ_NAME in
-    centos*-* | almalinux*-* | rockylinux*-*)
-	for host in $gfmds $gfsds $clients; do
-	   ssh "$host" sudo cp ${CA_DIR}/cacert.pem /usr/share/pki/ca-trust-source/anchors
-	   ssh "$host" sudo update-ca-trust
-        done
-        ;;
-    ubuntu*-* | debian*-*)
-	for host in $gfmds $gfsds $clients; do
-	   ssh "$host" sudo mkdir -p /usr/share/ca-certificates/gfarm
-	   ssh "$host" sudo cp ${CA_DIR}/cacert.pem /usr/share/ca-certificates/gfarm
-	   ssh "$host" "echo 'gfarm/cacert.pem' | sudo tee -a /etc/ca-certificates.conf"
-	   ssh "$host" sudo update-ca-certificates
-        done
-        ;;
-    *)
-	;;
+  centos*-* | almalinux*-* | rockylinux*-*)
+    for host in $gfmds $gfsds $clients; do
+      ssh "$host" "sudo cp ${CA_DIR}/cacert.pem /usr/share/pki/ca-trust-source/anchors"
+      ssh "$host" "sudo update-ca-trust"
+    done
+    ;;
+  ubuntu*-* | debian*-*)
+    for host in $gfmds $gfsds $clients; do
+      ssh "$host" "sudo mkdir -p /usr/share/ca-certificates/gfarm"
+      ssh "$host" "sudo cp ${CA_DIR}/cacert.pem /usr/share/ca-certificates/gfarm"
+      ssh "$host" "echo 'gfarm/cacert.pem' | sudo tee -a /etc/ca-certificates.conf"
+      ssh "$host" "sudo update-ca-certificates"
+    done
+    ;;
+  opensuse*-*)
+    for host in $gfmds $gfsds $clients; do
+      # openSUSE uses systemd path unit to auto-update CA trust store.
+      # No explicit update-ca-certificates call is needed.
+
+      ssh "$host" "sudo cp ${CA_DIR}/cacert.pem /etc/pki/trust/anchors"
+
+      # VS Code consumes many inotify watches, so this may be necessary
+      # when running under WSL.
+
+      # ssh "$host" "
+      #   if systemctl is-failed ca-certificates.path > /dev/null 2>&1; then
+      #     echo 'ca-certificates.path failed -> increase inotify watches'
+      #
+      #     current=$(cat /proc/sys/fs/inotify/max_user_watches)
+      #     if [ "$current" -lt 524288 ]; then
+      #       # Note: this also affects the host system.
+      #       sudo sysctl fs.inotify.max_user_watches=524288
+      #     fi
+      #
+      #     sudo systemctl restart ca-certificates.path || true
+      #   fi
+      # "
+    done
+    ;;
+  *)
+    ;;
 esac
 
 stty sane


### PR DESCRIPTION
* build jwt-agent regardless of proxy configuration

* install CA certificates on openSUSE to enable JWT retrieval