### PR TITLE
config-gfarm: support custom gfsd service names in unconfig

### DIFF
--- a/gftool/config-gfarm/config-gfsd.in
+++ b/gftool/config-gfarm/config-gfsd.in
@@ -282,13 +282,14 @@ unconfig()
 	-e "s|@config_gfarm_prefix@|$prefix|g" \
 	-e "s|@config_gfarm_datadir@|$datadir|g" \
 	-e "s|@config_gfarm_spool_directory@|$SPOOL_DIRECTORY|g" \
+	-e "s|@config_gfarm_gfsd_rc_name@|$GFSD_SERVICE_NAME|g" \
 	-e "s|@config_gfarm_rc_gfsd@|$RC_GFSD|g" \
 	-e "s|@config_gfarm_gfsd_pid_file@|$GFSD_PID_FILE|g" \
 	-e "s|@config_gfarm_gfarm_config@|$GFARM_CONF|g" \
 	-e "s|@config_gfarm_gfarm_client_config@|$GFARM_CLIENT_CONF|g" \
 	-e "s|@config_gfarm_gfarm_conf_dir@|$GFARM_CONF_DIR|g" \
 	-e "s|@config_gfarm_config_prefix@|$CONFIG_PREFIX|g" \
-        -e "s|@config_gfarm_private_mode@|$PRIVATE_MODE|g" \
+	-e "s|@config_gfarm_private_mode@|$PRIVATE_MODE|g" \
 	-e "s|@config_gfarm_usermap_file@|$USERMAP_FILE|g" \
 	-e "s|@config_gfarm_gfsd_hostname@|$GFSD_HOSTNAME|g" \
 	${1+"$@"}

--- a/gftool/config-gfarm/unconfig-gfsd.sh.in
+++ b/gftool/config-gfarm/unconfig-gfsd.sh.in
@@ -16,6 +16,7 @@ prefix="@config_gfarm_prefix@"
 datadir="@config_gfarm_datadir@"
 config_dir="${datadir}/gfarm/config"
 SPOOL_DIRECTORY="@config_gfarm_spool_directory@"
+GFSD_SERVICE_NAME="@config_gfarm_gfsd_rc_name@"
 RC_GFSD="@config_gfarm_rc_gfsd@"
 GFSD_PID_FILE="@config_gfarm_gfsd_pid_file@"
 GFARM_CONF="@config_gfarm_gfarm_config@"
@@ -80,9 +81,9 @@ service_unconfig()
 		TEST_OPT="-n"
 	fi
 
-	service_ctl $TEST_OPT gfsd stop
+	service_ctl $TEST_OPT "$GFSD_SERVICE_NAME" stop
 
-	service_remove $TEST_OPT gfsd
+	service_remove $TEST_OPT "$GFSD_SERVICE_NAME"
 
 	delete_file_or_directory -f $TEST_OPT "$RC_GFSD"
 


### PR DESCRIPTION
Issue #1197 (unconfig-gfsd.sh does not support custom gfsd service names)

* pass the configured gfsd service name to
  unconfig-gfsd.sh

* use the configured service name instead of the
  hard-coded "gfsd" service

Fixes #1197
